### PR TITLE
Add Google Scholar metadata to blog posts

### DIFF
--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -1,0 +1,14 @@
+{%- if page.scholar_authors -%}
+<meta name="citation_title" content="{{ page.title }}">
+{%- for author in page.scholar_authors %}
+<meta name="citation_author" content="{{ author }}">
+{%- endfor %}
+<meta name="citation_publication_date" content="{{ page.date | date: '%Y/%m/%d' }}">
+<meta name="citation_online_date" content="{{ page.date | date: '%Y/%m/%d' }}">
+<meta name="citation_journal_title" content="{{ page.citation_journal | default: 'Marin Community Blog' }}">
+<meta name="citation_language" content="{{ page.citation_language | default: 'en' }}">
+<meta name="citation_abstract_html_url" content="{{ page.url | absolute_url }}">
+{%- if page.pdf_url %}
+<meta name="citation_pdf_url" content="{{ page.pdf_url | absolute_url }}">
+{%- endif %}
+{%- endif %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -11,6 +11,12 @@ layout: default
 {% endfor %}
 </p>
 
+{% if page.pdf_url %}
+<p style="text-align: center; margin: 20px 0;">
+  <a href="{{ page.pdf_url | relative_url }}">Download PDF</a>
+</p>
+{% endif %}
+
 <hr/>
 
 {{content}}

--- a/_posts/2025-05-19-announcement.md
+++ b/_posts/2025-05-19-announcement.md
@@ -6,6 +6,30 @@ authors:
 - Ahmed Ahmed, Christopher Chou, Abhinav Garg, Rohith Kuditipudi, Will Held, Nikil Ravi, Herumb Shandilya, Jason Wang
 - Jason Bolton, Siddharth Karamcheti, Suhas Kotha, Tony Lee, Nelson Liu, Joel Niklaus, Ashwin Ramaswami, Kamyar Salahi, Kaiyue Wen, Chi Heem Wong, Sherry Yang, Ivan Zhou
 - Percy Liang
+scholar_authors:
+- "Hall, David"
+- "Ahmed, Ahmed"
+- "Chou, Christopher"
+- "Garg, Abhinav"
+- "Kuditipudi, Rohith"
+- "Held, Will"
+- "Ravi, Nikil"
+- "Shandilya, Herumb"
+- "Wang, Jason"
+- "Bolton, Jason"
+- "Karamcheti, Siddharth"
+- "Kotha, Suhas"
+- "Lee, Tony"
+- "Liu, Nelson"
+- "Niklaus, Joel"
+- "Ramaswami, Ashwin"
+- "Salahi, Kamyar"
+- "Wen, Kaiyue"
+- "Wong, Chi Heem"
+- "Yang, Sherry"
+- "Zhou, Ivan"
+- "Liang, Percy"
+pdf_url: /assets/papers/2025-05-19-marin-announcement.pdf
 date: 2025-05-19
 categories: blog
 ---


### PR DESCRIPTION
## Summary
Makes blog posts discoverable by the Google Scholar crawler via [Highwire Press meta tags](https://scholar.google.com/intl/en/scholar/inclusion.html#indexing). Opt-in via frontmatter so it only affects posts that want to be indexed.

**New post frontmatter fields** (both required for Scholar to index):
- `scholar_authors`: flat list of `"Last, First"` strings
- `pdf_url`: path to a same-domain PDF of the post

Scholar treats `citation_pdf_url` pointing at a real PDF as a hard "this is a publication" signal — HTML-only pages are essentially never indexed. The existing `authors` field is kept for the post's visual grouping and stays decoupled from the scholarly metadata.

## What's in this PR
- `_includes/head-custom.html` — emits `citation_title`, `citation_author` (one per author), `citation_publication_date`, `citation_online_date`, `citation_journal_title`, `citation_language`, `citation_abstract_html_url`, and `citation_pdf_url` when `page.scholar_authors` is set. Overrides the theme's empty default include.
- `_layouts/post.html` — renders a "Download PDF" link below the author list when `page.pdf_url` is set.
- `_posts/2025-05-19-announcement.md` — adds `scholar_authors` (22 entries matching the post's author list) and `pdf_url: /assets/papers/2025-05-19-marin-announcement.pdf`.

## Still needed before Scholar will index
- [ ] Upload the actual PDF to `/assets/papers/2025-05-19-marin-announcement.pdf`. The PDF should look paper-shaped: title + authors at top, a short abstract, the body, and a References section with real citations — Scholar's text extractor uses those to verify it's a publication. A plain print-to-PDF will technically work but yields worse indexing.
- [ ] (Strongly recommended) Get at least one `.edu` page (crfm.stanford.edu or hai.stanford.edu) to link to the PDF. Scholar's crawler deprioritizes unknown domains; one inbound link from a trusted site is the biggest accelerator.
- [ ] Co-authors manually add the post to their Google Scholar profiles (independent of crawler — profile pages are crawled too).

Timeline after those are in place: **2–8 weeks** for first indexing. There is no submission form and no status page.

## Test plan
- [x] `bundle exec jekyll serve` — rendered page contains all 22 `citation_author` meta tags plus the other `citation_*` tags, verified via curl.
- [x] "Download PDF" link renders below the author list.
- [x] Meta tags are gated behind `page.scholar_authors`, so posts without scholar metadata are unaffected.
- [ ] Reviewer: confirm author ordering / name formatting (`Last, First`) matches expectations.

## Follow-ups (out of scope)
- Verify `robots.txt` and `sitemap.xml` on the deployed site allow Googlebot and Googlebot-Scholar. The `github-pages` gem ships `jekyll-sitemap` by default, so sitemap generation is probably already fine.
- Pattern is reusable for future posts — just add the two frontmatter fields and host the PDF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)