### PR TITLE
[codex] Add tokenizer sensitivity gap dashboard

### DIFF
--- a/analysis/tokenizer-sensitivity-gap/dashboard.css
+++ b/analysis/tokenizer-sensitivity-gap/dashboard.css
@@ -1,0 +1,651 @@
+:root {
+  color-scheme: light;
+  --bg: #f5f7fb;
+  --panel: #ffffff;
+  --panel-muted: #f0f3f8;
+  --border: #d9e0ec;
+  --border-strong: #bcc8da;
+  --ink: #151922;
+  --muted: #5f6b7d;
+  --faint: #8792a5;
+  --accent: #315aa8;
+  --accent-soft: #e8eefb;
+  --good: #087f67;
+  --good-soft: #e4f5f0;
+  --bad: #bd3e34;
+  --bad-soft: #fce8e5;
+  --zero: #7a8494;
+  --shadow: 0 12px 28px rgba(24, 34, 55, 0.08);
+  --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+code {
+  font-family: var(--mono);
+  font-size: 0.94em;
+}
+
+.shell {
+  width: min(1480px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 26px 0 42px;
+}
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: end;
+  gap: 22px;
+  margin-bottom: 18px;
+}
+
+.eyebrow {
+  margin: 0 0 7px;
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(28px, 3vw, 42px);
+  line-height: 1.04;
+  letter-spacing: 0;
+}
+
+.lede {
+  max-width: 850px;
+  margin: 10px 0 0;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.source-links {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: end;
+}
+
+.source-links a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  padding: 7px 11px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel);
+  color: var(--ink);
+  box-shadow: 0 2px 8px rgba(24, 34, 55, 0.04);
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.summary-card,
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+}
+
+.summary-card {
+  padding: 14px;
+  min-height: 118px;
+}
+
+.summary-label {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 750;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.summary-value {
+  margin-top: 11px;
+  font-size: 25px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.summary-name {
+  margin-top: 9px;
+  color: var(--ink);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.summary-note {
+  margin-top: 5px;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.sidebar {
+  position: sticky;
+  top: 16px;
+  padding: 14px;
+}
+
+.panel {
+  padding: 16px;
+}
+
+.content {
+  display: grid;
+  gap: 16px;
+}
+
+.panel-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: start;
+  margin-bottom: 12px;
+}
+
+h2 {
+  margin: 0;
+  font-size: 15px;
+  letter-spacing: 0.02em;
+}
+
+.panel-head p,
+.notes,
+.dataset-meta,
+.example-meta {
+  margin: 5px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+h3 {
+  margin: 0 0 9px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.candidate-list {
+  display: grid;
+  gap: 8px;
+}
+
+.candidate-button {
+  width: 100%;
+  text-align: left;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #fff;
+  color: var(--ink);
+  cursor: pointer;
+  padding: 11px;
+  transition: border-color 120ms ease, box-shadow 120ms ease, transform 120ms ease;
+}
+
+.candidate-button:hover {
+  border-color: var(--accent);
+  transform: translateY(-1px);
+}
+
+.candidate-button.active {
+  border-color: var(--accent);
+  box-shadow: inset 0 0 0 1px rgba(49, 90, 168, 0.22);
+  background: var(--accent-soft);
+}
+
+.candidate-title {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+  font-size: 14px;
+  font-weight: 750;
+}
+
+.candidate-subtitle {
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.notes {
+  display: grid;
+  gap: 8px;
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border);
+}
+
+.selected-panel {
+  border-color: var(--border-strong);
+}
+
+.selected-score {
+  text-align: right;
+  font-size: 28px;
+  font-weight: 850;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.group-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.group-card,
+.move-row,
+.example-card {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--panel-muted);
+}
+
+.group-card {
+  padding: 12px;
+}
+
+.group-name {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 750;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.group-value {
+  margin-top: 8px;
+  font-size: 22px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+}
+
+.group-detail {
+  margin-top: 5px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.split {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+  gap: 16px;
+}
+
+.move-columns,
+.example-columns {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.move-list,
+.example-list,
+.heatmap-list {
+  display: grid;
+  gap: 8px;
+}
+
+.move-row {
+  padding: 10px;
+}
+
+.move-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: baseline;
+}
+
+.move-name {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.move-gap {
+  flex: 0 0 auto;
+  font-size: 13px;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+}
+
+.mini-bar,
+.bar {
+  position: relative;
+  overflow: hidden;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(8, 127, 103, 0.10) 0 50%, rgba(189, 62, 52, 0.10) 50% 100%);
+}
+
+.mini-bar {
+  height: 9px;
+  margin-top: 9px;
+}
+
+.bar {
+  height: 13px;
+  min-width: 130px;
+}
+
+.mini-bar::after,
+.bar::after {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 50%;
+  width: 1px;
+  background: var(--zero);
+}
+
+.bar-fill {
+  position: absolute;
+  top: 1px;
+  height: calc(100% - 2px);
+  border-radius: 999px;
+}
+
+.bar-fill.negative {
+  right: 50%;
+  background: var(--good);
+}
+
+.bar-fill.positive {
+  left: 50%;
+  background: var(--bad);
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 10px 8px;
+  border-top: 1px solid var(--border);
+  text-align: left;
+  vertical-align: middle;
+}
+
+th {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+td {
+  font-size: 13px;
+}
+
+td.metric {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+td.name-cell {
+  min-width: 260px;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.score-table td.name-cell {
+  min-width: 170px;
+}
+
+.score-table th,
+.score-table td {
+  padding-right: 6px;
+  padding-left: 6px;
+}
+
+.controls-head {
+  align-items: center;
+}
+
+.controls {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: end;
+}
+
+.search,
+select {
+  min-height: 36px;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: #fff;
+  color: var(--ink);
+  padding: 7px 10px;
+  font: inherit;
+  font-size: 13px;
+}
+
+.search {
+  width: min(270px, 100%);
+}
+
+.example-card,
+.heatmap-card {
+  padding: 10px;
+  background: #fff;
+}
+
+.example-title,
+.heatmap-title {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 13px;
+  font-weight: 750;
+}
+
+.example-preview,
+.heatmap-preview {
+  margin: 9px 0 0;
+  max-height: 13em;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #f8fafd;
+  color: #273142;
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.45;
+  padding: 9px;
+  white-space: pre-wrap;
+}
+
+.heatmap-toolbar {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: -2px 0 12px;
+}
+
+.heatmap-tab {
+  min-height: 34px;
+  border: 1px solid var(--border-strong);
+  border-radius: 8px;
+  background: #fff;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 7px 11px;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.heatmap-tab.active {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+  color: var(--ink);
+}
+
+.heatmap-card {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.heatmap-target {
+  border-radius: 5px;
+  padding: 0 2px;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+}
+
+.heatmap-target.bad {
+  background: rgba(189, 62, 52, var(--heat-alpha, 0.32));
+  color: #3e100c;
+}
+
+.heatmap-target.good {
+  background: rgba(8, 127, 103, var(--heat-alpha, 0.32));
+  color: #062a24;
+}
+
+.token-boundaries {
+  display: grid;
+  gap: 5px;
+  margin-top: 8px;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
+.segment-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  margin-top: 8px;
+  padding: 2px 7px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel-muted);
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 11px;
+  overflow-wrap: anywhere;
+}
+
+.good {
+  color: var(--good);
+}
+
+.bad {
+  color: var(--bad);
+}
+
+.neutral {
+  color: var(--zero);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 2px 7px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: #fff;
+  color: var(--muted);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+@media (max-width: 1180px) {
+  .summary-grid,
+  .group-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .layout,
+  .split {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: static;
+  }
+}
+
+@media (max-width: 720px) {
+  .shell {
+    width: min(100vw - 20px, 1480px);
+    padding-top: 16px;
+  }
+
+  .topbar,
+  .panel-head,
+  .controls-head,
+  .move-columns,
+  .example-columns {
+    display: block;
+  }
+
+  .source-links,
+  .controls {
+    justify-content: start;
+    margin-top: 12px;
+  }
+
+  .summary-grid,
+  .group-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .selected-score {
+    margin-top: 10px;
+    text-align: left;
+  }
+}

--- a/analysis/tokenizer-sensitivity-gap/dashboard.js
+++ b/analysis/tokenizer-sensitivity-gap/dashboard.js
@@ -1,0 +1,445 @@
+const ASSET_VERSION = "20260528-heatmaps";
+
+const response = await fetch(`./data.json?v=${ASSET_VERSION}`);
+if (!response.ok) {
+  throw new Error(`Failed to load tokenizer dashboard data: ${response.status} ${response.statusText}`);
+}
+const DATA = await response.json();
+
+const elements = {
+  summaryGrid: document.getElementById("summary-grid"),
+  candidateList: document.getElementById("candidate-list"),
+  notes: document.getElementById("notes"),
+  gapMatrix: document.getElementById("gap-matrix"),
+  selectedTitle: document.getElementById("selected-title"),
+  selectedSubtitle: document.getElementById("selected-subtitle"),
+  selectedScore: document.getElementById("selected-score"),
+  groupGrid: document.getElementById("group-grid"),
+  biggestWins: document.getElementById("biggest-wins"),
+  biggestLosses: document.getElementById("biggest-losses"),
+  scoreTable: document.getElementById("score-table"),
+  datasetSearch: document.getElementById("dataset-search"),
+  datasetSort: document.getElementById("dataset-sort"),
+  datasetCount: document.getElementById("dataset-count"),
+  datasetTable: document.getElementById("dataset-table"),
+  bucketTable: document.getElementById("bucket-table"),
+  heatmapTabs: document.getElementById("heatmap-tabs"),
+  heatmapsWorse: document.getElementById("heatmaps-worse"),
+  heatmapsBetter: document.getElementById("heatmaps-better"),
+  examplesWorse: document.getElementById("examples-worse"),
+  examplesBetter: document.getElementById("examples-better"),
+};
+
+const gapByModel = new Map(DATA.gaps.map((gap) => [gap.model, gap]));
+const scoreByModel = new Map(DATA.scores.map((score) => [score.model, score]));
+const heatmapViews = [
+  { id: "segments", label: "Local spans" },
+  { id: "literals", label: "Repeated literals" },
+];
+let selectedModel = gapByModel.has(location.hash.slice(1)) ? location.hash.slice(1) : DATA.gaps[0].model;
+let selectedHeatmapView = "segments";
+
+elements.datasetSearch.addEventListener("input", renderDatasetTable);
+elements.datasetSort.addEventListener("change", renderDatasetTable);
+window.addEventListener("hashchange", () => {
+  const model = location.hash.slice(1);
+  if (gapByModel.has(model)) {
+    selectedModel = model;
+    render();
+  }
+});
+
+render();
+
+function render() {
+  renderSummary();
+  renderCandidates();
+  renderNotes();
+  renderHeatmapTabs();
+  renderGapMatrix();
+  renderSelected();
+  renderScores();
+}
+
+function renderSummary() {
+  const best = DATA.gaps[0];
+  const qwen = gapByModel.get("qwen3-152k");
+  const tokenmonster = gapByModel.get("tokenmonster-englishcode-32k");
+  const gptOss = gapByModel.get("gpt-oss-200k");
+  const cards = [
+    {
+      label: "Best overall",
+      value: formatGap(best.overall_gap_bpb),
+      tone: toneForGap(best.overall_gap_bpb),
+      name: best.model,
+      note: `${best.wins}/${best.datasets.length} dataset slices better than llama3-128k.`,
+    },
+    {
+      label: "Close second",
+      value: formatGap(gptOss.overall_gap_bpb),
+      tone: toneForGap(gptOss.overall_gap_bpb),
+      name: gptOss.model,
+      note: "Broadly improves Paloma and Uncheatable, with a few text-tail regressions.",
+    },
+    {
+      label: "Qwen status",
+      value: formatGap(qwen.overall_gap_bpb),
+      tone: toneForGap(qwen.overall_gap_bpb),
+      name: qwen.model,
+      note: "Near parity overall, with code slices worse and some social/text slices better.",
+    },
+    {
+      label: "TokenMonster patch",
+      value: formatGap(tokenmonster.overall_gap_bpb),
+      tone: toneForGap(tokenmonster.overall_gap_bpb),
+      name: tokenmonster.model,
+      note: "Byte-accounting patch flips the earlier readout: code wins remain, ordinary text loses.",
+    },
+  ];
+  elements.summaryGrid.innerHTML = cards.map((card) => `
+    <article class="summary-card">
+      <div class="summary-label">${escapeHtml(card.label)}</div>
+      <div class="summary-value ${card.tone}">${card.value}</div>
+      <div class="summary-name">${escapeHtml(card.name)}</div>
+      <div class="summary-note">${escapeHtml(card.note)}</div>
+    </article>
+  `).join("");
+}
+
+function renderCandidates() {
+  elements.candidateList.innerHTML = DATA.gaps.map((gap) => {
+    const isActive = gap.model === selectedModel;
+    return `
+      <button class="candidate-button ${isActive ? "active" : ""}" data-model="${escapeAttr(gap.model)}" type="button">
+        <div class="candidate-title">
+          <span>${escapeHtml(gap.model)}</span>
+          <span class="${toneForGap(gap.overall_gap_bpb)}">${formatGap(gap.overall_gap_bpb)}</span>
+        </div>
+        <div class="candidate-subtitle">${gap.wins} wins / ${gap.losses} losses · ${formatGap(gap.paloma_gap_bpb)} Paloma</div>
+      </button>
+    `;
+  }).join("");
+  for (const button of elements.candidateList.querySelectorAll("button")) {
+    button.addEventListener("click", () => {
+      selectedModel = button.dataset.model;
+      history.replaceState(null, "", `#${selectedModel}`);
+      render();
+    });
+  }
+}
+
+function renderNotes() {
+  elements.notes.innerHTML = DATA.notes.map((note) => `<div>${escapeHtml(note)}</div>`).join("");
+}
+
+function renderGapMatrix() {
+  elements.gapMatrix.innerHTML = DATA.gaps.map((gap) => `
+    <tr>
+      <td class="name-cell">${escapeHtml(gap.model)}</td>
+      ${metricCell(gap.overall_gap_bpb)}
+      ${metricCell(gap.paloma_gap_bpb)}
+      ${metricCell(gap.uncheatable_gap_bpb)}
+      <td>${gap.wins} / ${gap.losses}</td>
+    </tr>
+  `).join("");
+}
+
+function renderSelected() {
+  const gap = gapByModel.get(selectedModel);
+  const score = scoreByModel.get(selectedModel);
+  elements.selectedTitle.textContent = gap.model;
+  elements.selectedSubtitle.textContent = DATA.models[gap.model] || gap.model;
+  elements.selectedScore.className = `selected-score ${toneForGap(gap.overall_gap_bpb)}`;
+  elements.selectedScore.textContent = formatGap(gap.overall_gap_bpb);
+  elements.groupGrid.innerHTML = [
+    ["Overall", gap.overall_gap_bpb, gap.bytes, gap.documents],
+    ["Paloma", gap.paloma_gap_bpb, findGroupBytes(gap, "paloma"), findGroupDocuments(gap, "paloma")],
+    ["Uncheatable", gap.uncheatable_gap_bpb, findGroupBytes(gap, "uncheatable_eval"), findGroupDocuments(gap, "uncheatable_eval")],
+  ].map(([name, value, bytes, docs]) => `
+    <article class="group-card">
+      <div class="group-name">${name}</div>
+      <div class="group-value ${toneForGap(value)}">${formatGap(value)}</div>
+      <div class="group-detail">${formatBytes(bytes)} · ${formatInteger(docs)} docs</div>
+    </article>
+  `).join("");
+
+  renderMoves(gap);
+  renderDatasetTable();
+  renderBucketTable(gap);
+  renderHeatmaps(gap);
+  renderExamples(gap);
+
+  if (score) {
+    document.title = `${gap.model} vs ${DATA.baseline} | Tokenizer Sensitivity d1024`;
+  }
+}
+
+function renderHeatmapTabs() {
+  elements.heatmapTabs.innerHTML = heatmapViews.map((view) => `
+    <button class="heatmap-tab ${view.id === selectedHeatmapView ? "active" : ""}" data-view="${view.id}" type="button">
+      ${escapeHtml(view.label)}
+    </button>
+  `).join("");
+  for (const button of elements.heatmapTabs.querySelectorAll("button")) {
+    button.addEventListener("click", () => {
+      selectedHeatmapView = button.dataset.view;
+      renderHeatmaps(gapByModel.get(selectedModel));
+      renderHeatmapTabs();
+    });
+  }
+}
+
+function renderMoves(gap) {
+  elements.biggestWins.innerHTML = gap.biggest_wins.map((row) => moveRow(row)).join("");
+  elements.biggestLosses.innerHTML = gap.biggest_losses.map((row) => moveRow(row)).join("");
+}
+
+function renderScores() {
+  elements.scoreTable.innerHTML = DATA.scores.map((score) => `
+    <tr>
+      <td class="name-cell">${escapeHtml(score.model)}</td>
+      <td class="metric">${formatBpb(score.overall_bpb)}</td>
+      <td class="metric">${formatBpb(score.paloma_bpb)}</td>
+      <td class="metric">${formatBpb(score.uncheatable_bpb)}</td>
+    </tr>
+  `).join("");
+}
+
+function renderDatasetTable() {
+  const gap = gapByModel.get(selectedModel);
+  const query = elements.datasetSearch.value.trim().toLowerCase();
+  const sort = elements.datasetSort.value;
+  let rows = gap.datasets;
+  if (query) {
+    rows = rows.filter((row) => row.name.toLowerCase().includes(query));
+  }
+  rows = [...rows].sort((a, b) => compareRows(a, b, sort));
+  elements.datasetCount.textContent = `${rows.length} of ${gap.datasets.length} slices shown.`;
+  elements.datasetTable.innerHTML = rows.map((row) => `
+    <tr>
+      <td class="name-cell">${escapeHtml(row.name)}<div class="dataset-meta">${formatInteger(row.documents)} docs</div></td>
+      ${metricCell(row.gap_bpb)}
+      <td class="metric">${formatBpb(row.model_a_bpb)}</td>
+      <td class="metric">${formatBpb(row.model_b_bpb)}</td>
+      <td class="metric">${formatBytes(row.bytes)}</td>
+      <td>${bar(row.gap_bpb, 0.08)}</td>
+    </tr>
+  `).join("");
+}
+
+function renderBucketTable(gap) {
+  const rows = [...gap.pattern_buckets].sort((a, b) => Math.abs(b.gap_bpb) - Math.abs(a.gap_bpb));
+  elements.bucketTable.innerHTML = rows.map((row) => `
+    <tr>
+      <td class="name-cell">${escapeHtml(row.name)}<div class="dataset-meta">${formatInteger(row.documents)} labeled spans</div></td>
+      ${metricCell(row.gap_bpb)}
+      <td class="metric">${formatBpb(row.model_a_bpb)}</td>
+      <td class="metric">${formatBpb(row.model_b_bpb)}</td>
+      <td class="metric">${formatBytes(row.bytes)}</td>
+      <td>${bar(row.gap_bpb, 0.06)}</td>
+    </tr>
+  `).join("");
+}
+
+function renderExamples(gap) {
+  elements.examplesWorse.innerHTML = exampleCards(gap.examples.model_a_worse || []);
+  elements.examplesBetter.innerHTML = exampleCards(gap.examples.model_b_worse || []);
+}
+
+function renderHeatmaps(gap) {
+  const key = selectedHeatmapView === "literals" ? "top_literals" : "top_segments";
+  elements.heatmapsWorse.innerHTML = heatmapCards(gap[key]?.model_a_worse || [], selectedHeatmapView, "bad");
+  elements.heatmapsBetter.innerHTML = heatmapCards(gap[key]?.model_b_worse || [], selectedHeatmapView, "good");
+}
+
+function moveRow(row) {
+  return `
+    <div class="move-row">
+      <div class="move-top">
+        <div class="move-name">${escapeHtml(row.name)}</div>
+        <div class="move-gap ${toneForGap(row.gap_bpb)}">${formatGap(row.gap_bpb)}</div>
+      </div>
+      ${bar(row.gap_bpb, 0.08, "mini-bar")}
+      <div class="dataset-meta">${formatBpb(row.model_a_bpb)} vs ${formatBpb(row.model_b_bpb)} BPB · ${formatBytes(row.bytes)}</div>
+    </div>
+  `;
+}
+
+function exampleCards(rows) {
+  if (!rows.length) {
+    return `<div class="dataset-meta">No examples in this bucket.</div>`;
+  }
+  return rows.slice(0, 5).map((row) => `
+    <article class="example-card">
+      <div class="example-title">
+        <span>${escapeHtml(row.dataset || "unknown dataset")}</span>
+        <span class="${toneForGap(row.gap_bpb)}">${formatGap(row.gap_bpb)}</span>
+      </div>
+      <div class="example-meta">
+        ${escapeHtml(row.shard || "unknown shard")} · row ${formatInteger(row.row_index)} · worst bucket ${escapeHtml(row.worst_bucket || "n/a")}
+      </div>
+      <pre class="example-preview">${escapeHtml(row.preview || "")}</pre>
+    </article>
+  `).join("");
+}
+
+function heatmapCards(rows, view, tone) {
+  if (!rows.length) {
+    return `<div class="dataset-meta">No heatmap rows in this bucket.</div>`;
+  }
+  return rows.slice(0, 8).map((row) => {
+    const gap = row.gap_bpb;
+    const alpha = Math.min(0.18 + Math.abs(gap) / 3, 0.78).toFixed(3);
+    if (view === "literals") {
+      return literalHeatmapCard(row, tone, alpha);
+    }
+    return segmentHeatmapCard(row, tone, alpha);
+  }).join("");
+}
+
+function segmentHeatmapCard(row, tone, alpha) {
+  const preview = row.doc_preview || "";
+  const text = row.text || "";
+  return `
+    <article class="heatmap-card">
+      <div class="heatmap-title">
+        <span>${escapeHtml(row.dataset || "unknown dataset")}</span>
+        <span class="${toneForGap(row.gap_bpb)}">${formatGap(row.gap_bpb)}</span>
+      </div>
+      <div class="example-meta">${escapeHtml(row.bucket || "unknown bucket")} · ${formatBytes(row.bytes)}</div>
+      <pre class="heatmap-preview">${highlightText(preview, text, tone, alpha)}</pre>
+      <div class="segment-chip">${escapeHtml(text)}</div>
+    </article>
+  `;
+}
+
+function literalHeatmapCard(row, tone, alpha) {
+  const preview = row.example_doc_preview || "";
+  const text = row.name || "";
+  return `
+    <article class="heatmap-card">
+      <div class="heatmap-title">
+        <span>${escapeHtml(row.example_dataset || "unknown dataset")}</span>
+        <span class="${toneForGap(row.gap_bpb)}">${formatGap(row.gap_bpb)}</span>
+      </div>
+      <div class="example-meta">${escapeHtml(row.bucket || "unknown bucket")} · ${formatInteger(row.documents)} hits · ${formatBytes(row.bytes)}</div>
+      <pre class="heatmap-preview">${highlightText(preview, text, tone, alpha)}</pre>
+      <div class="segment-chip">${escapeHtml(text)}</div>
+      <div class="token-boundaries">
+        <div>candidate: ${escapeHtml(row.model_a_token_boundaries || "n/a")}</div>
+        <div>baseline: ${escapeHtml(row.model_b_token_boundaries || "n/a")}</div>
+      </div>
+    </article>
+  `;
+}
+
+function highlightText(preview, target, tone, alpha) {
+  const safePreview = escapeHtml(preview);
+  const normalizedTarget = String(target || "").replaceAll("…", "");
+  if (!normalizedTarget) {
+    return safePreview;
+  }
+  const escapedTarget = escapeHtml(normalizedTarget);
+  const exactIndex = safePreview.indexOf(escapedTarget);
+  if (exactIndex >= 0) {
+    return `${safePreview.slice(0, exactIndex)}<span class="heatmap-target ${tone}" style="--heat-alpha:${alpha}">${escapedTarget}</span>${safePreview.slice(exactIndex + escapedTarget.length)}`;
+  }
+  const compactTarget = escapedTarget.trim();
+  if (compactTarget.length >= 4) {
+    const compactIndex = safePreview.indexOf(compactTarget);
+    if (compactIndex >= 0) {
+      return `${safePreview.slice(0, compactIndex)}<span class="heatmap-target ${tone}" style="--heat-alpha:${alpha}">${compactTarget}</span>${safePreview.slice(compactIndex + compactTarget.length)}`;
+    }
+  }
+  return safePreview;
+}
+
+function metricCell(value) {
+  return `<td class="metric ${toneForGap(value)}">${formatGap(value)}</td>`;
+}
+
+function compareRows(a, b, sort) {
+  if (sort === "gap") {
+    return a.gap_bpb - b.gap_bpb;
+  }
+  if (sort === "name") {
+    return a.name.localeCompare(b.name);
+  }
+  return Math.abs(b.gap_bpb) - Math.abs(a.gap_bpb);
+}
+
+function findGroupBytes(gap, name) {
+  return gap.dataset_groups.find((group) => group.name === name)?.bytes ?? gap.bytes;
+}
+
+function findGroupDocuments(gap, name) {
+  return gap.dataset_groups.find((group) => group.name === name)?.documents ?? gap.documents;
+}
+
+function bar(value, scale = 0.08, className = "bar") {
+  const clipped = Math.min(Math.abs(value) / scale, 1) * 50;
+  const direction = value < 0 ? "negative" : "positive";
+  return `
+    <div class="${className}" aria-label="${formatGap(value)}">
+      <div class="bar-fill ${direction}" style="width:${clipped.toFixed(2)}%"></div>
+    </div>
+  `;
+}
+
+function toneForGap(value) {
+  if (value < -0.00005) {
+    return "good";
+  }
+  if (value > 0.00005) {
+    return "bad";
+  }
+  return "neutral";
+}
+
+function formatGap(value) {
+  if (!Number.isFinite(value)) {
+    return "n/a";
+  }
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${value.toFixed(5)}`;
+}
+
+function formatBpb(value) {
+  if (!Number.isFinite(value)) {
+    return "n/a";
+  }
+  return value.toFixed(5);
+}
+
+function formatBytes(value) {
+  if (!Number.isFinite(value)) {
+    return "n/a";
+  }
+  if (value >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(2)} MB`;
+  }
+  if (value >= 1_000) {
+    return `${(value / 1_000).toFixed(1)} KB`;
+  }
+  return `${value} B`;
+}
+
+function formatInteger(value) {
+  if (!Number.isFinite(value)) {
+    return "n/a";
+  }
+  return new Intl.NumberFormat("en-US").format(value);
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+function escapeAttr(value) {
+  return escapeHtml(value).replaceAll("`", "&#096;");
+}

--- a/analysis/tokenizer-sensitivity-gap/data.json
+++ b/analysis/tokenizer-sensitivity-gap/data.json
@@ -1,0 +1,6292 @@
+{
+  "baseline": "llama3-128k",
+  "gap_prefix": "gs://marin-eu-west4/analysis/perplexity_gap/tokenizer-sensitivity-d1024/",
+  "gaps": [
+    {
+      "baseline": "llama3-128k",
+      "biggest_losses": [
+        {
+          "bytes": 32768,
+          "delta_bits": 2390.1959502818445,
+          "documents": 1,
+          "gap_bpb": 0.0729429916467848,
+          "model_a_bpb": 1.207461719087488,
+          "model_b_bpb": 1.1345187274407031,
+          "name": "paloma/ptb"
+        },
+        {
+          "bytes": 5472253,
+          "delta_bits": 11282.801863313829,
+          "documents": 167,
+          "gap_bpb": 0.002061820216154814,
+          "model_a_bpb": 0.9471095472115831,
+          "model_b_bpb": 0.9450477269954284,
+          "name": "paloma/m2d2_s2orc_unsplit"
+        },
+        {
+          "bytes": 635606,
+          "delta_bits": 181.41220324352676,
+          "documents": 256,
+          "gap_bpb": 0.00028541612766954175,
+          "model_a_bpb": 0.9594561202658204,
+          "model_b_bpb": 0.9591707041381508,
+          "name": "uncheatable_eval/wikipedia_english"
+        },
+        {
+          "bytes": 1223044,
+          "delta_bits": -757.5955381563381,
+          "documents": 256,
+          "gap_bpb": -0.0006194344096830025,
+          "model_a_bpb": 1.1140732333314185,
+          "model_b_bpb": 1.1146926677411015,
+          "name": "uncheatable_eval/ao3_english"
+        },
+        {
+          "bytes": 974819,
+          "delta_bits": -765.8410640674766,
+          "documents": 256,
+          "gap_bpb": -0.0007856238584470313,
+          "model_a_bpb": 0.9674530430606904,
+          "model_b_bpb": 0.9682386669191374,
+          "name": "paloma/mc4"
+        }
+      ],
+      "biggest_wins": [
+        {
+          "bytes": 37599,
+          "delta_bits": -938.2048898412554,
+          "documents": 256,
+          "gap_bpb": -0.024952921350069296,
+          "model_a_bpb": 1.649096095455438,
+          "model_b_bpb": 1.6740490168055073,
+          "name": "paloma/gab"
+        },
+        {
+          "bytes": 876685,
+          "delta_bits": -20735.435526858666,
+          "documents": 256,
+          "gap_bpb": -0.023652093427922988,
+          "model_a_bpb": 0.6159249412691202,
+          "model_b_bpb": 0.6395770346970432,
+          "name": "uncheatable_eval/github_cpp"
+        },
+        {
+          "bytes": 1006410,
+          "delta_bits": -18348.522751146724,
+          "documents": 256,
+          "gap_bpb": -0.01823165782449173,
+          "model_a_bpb": 0.5642952112385489,
+          "model_b_bpb": 0.5825268690630405,
+          "name": "uncheatable_eval/github_python"
+        },
+        {
+          "bytes": 1067444,
+          "delta_bits": -17277.244000101655,
+          "documents": 256,
+          "gap_bpb": -0.016185620978806995,
+          "model_a_bpb": 1.1477514873294559,
+          "model_b_bpb": 1.1639371083082628,
+          "name": "paloma/4chan"
+        },
+        {
+          "bytes": 1000476,
+          "delta_bits": -15334.012862355952,
+          "documents": 256,
+          "gap_bpb": -0.01532671734489978,
+          "model_a_bpb": 1.1651025700607989,
+          "model_b_bpb": 1.1804292874056987,
+          "name": "paloma/manosphere_meta_sep"
+        }
+      ],
+      "bytes": 23108960,
+      "dataset_groups": [
+        {
+          "bytes": 16006023,
+          "delta_bits": -42434.85281792473,
+          "documents": 3348,
+          "gap_bpb": -0.0026511802974370792,
+          "model_a_bpb": 0.9776687588747509,
+          "model_b_bpb": 0.9803199391721881,
+          "name": "paloma"
+        },
+        {
+          "bytes": 7102937,
+          "delta_bits": -51752.640672806054,
+          "documents": 1792,
+          "gap_bpb": -0.007286090341615877,
+          "model_a_bpb": 0.8512315696117071,
+          "model_b_bpb": 0.8585176599533229,
+          "name": "uncheatable_eval"
+        }
+      ],
+      "datasets": [
+        {
+          "bytes": 1067444,
+          "delta_bits": -17277.244000101655,
+          "documents": 256,
+          "gap_bpb": -0.016185620978806995,
+          "model_a_bpb": 1.1477514873294559,
+          "model_b_bpb": 1.1639371083082628,
+          "name": "paloma/4chan"
+        },
+        {
+          "bytes": 744402,
+          "delta_bits": -1274.3848362023007,
+          "documents": 256,
+          "gap_bpb": -0.0017119578348826316,
+          "model_a_bpb": 0.9995167818368677,
+          "model_b_bpb": 1.0012287396717503,
+          "name": "paloma/c4_100_domains"
+        },
+        {
+          "bytes": 523373,
+          "delta_bits": -1496.1062502187704,
+          "documents": 256,
+          "gap_bpb": -0.0028585850821856887,
+          "model_a_bpb": 0.9751015235127045,
+          "model_b_bpb": 0.9779601085948901,
+          "name": "paloma/c4_en"
+        },
+        {
+          "bytes": 858825,
+          "delta_bits": -1082.933508983332,
+          "documents": 256,
+          "gap_bpb": -0.0012609478170562479,
+          "model_a_bpb": 1.0292039699235138,
+          "model_b_bpb": 1.03046491774057,
+          "name": "paloma/dolma-v1_5"
+        },
+        {
+          "bytes": 898445,
+          "delta_bits": -7561.236557965167,
+          "documents": 256,
+          "gap_bpb": -0.008415914783837816,
+          "model_a_bpb": 0.6520751202352753,
+          "model_b_bpb": 0.6604910350191131,
+          "name": "paloma/dolma_100_programing_languages"
+        },
+        {
+          "bytes": 204005,
+          "delta_bits": -964.0648273043145,
+          "documents": 256,
+          "gap_bpb": -0.004725692151193914,
+          "model_a_bpb": 1.1252393286286742,
+          "model_b_bpb": 1.1299650207798682,
+          "name": "paloma/dolma_100_subreddits"
+        },
+        {
+          "bytes": 700803,
+          "delta_bits": -708.6768659267832,
+          "documents": 256,
+          "gap_bpb": -0.0010112354911819487,
+          "model_a_bpb": 1.03084580659858,
+          "model_b_bpb": 1.0318570420897617,
+          "name": "paloma/falcon-refinedweb"
+        },
+        {
+          "bytes": 37599,
+          "delta_bits": -938.2048898412554,
+          "documents": 256,
+          "gap_bpb": -0.024952921350069296,
+          "model_a_bpb": 1.649096095455438,
+          "model_b_bpb": 1.6740490168055073,
+          "name": "paloma/gab"
+        },
+        {
+          "bytes": 5472253,
+          "delta_bits": 11282.801863313829,
+          "documents": 167,
+          "gap_bpb": 0.002061820216154814,
+          "model_a_bpb": 0.9471095472115831,
+          "model_b_bpb": 0.9450477269954284,
+          "name": "paloma/m2d2_s2orc_unsplit"
+        },
+        {
+          "bytes": 1605632,
+          "delta_bits": -3694.8825146672716,
+          "documents": 49,
+          "gap_bpb": -0.002301201342939896,
+          "model_a_bpb": 0.9529107352703711,
+          "model_b_bpb": 0.9552119366133109,
+          "name": "paloma/m2d2_wikipedia_unsplit"
+        },
+        {
+          "bytes": 1000476,
+          "delta_bits": -15334.012862355952,
+          "documents": 256,
+          "gap_bpb": -0.01532671734489978,
+          "model_a_bpb": 1.1651025700607989,
+          "model_b_bpb": 1.1804292874056987,
+          "name": "paloma/manosphere_meta_sep"
+        },
+        {
+          "bytes": 974819,
+          "delta_bits": -765.8410640674766,
+          "documents": 256,
+          "gap_bpb": -0.0007856238584470313,
+          "model_a_bpb": 0.9674530430606904,
+          "model_b_bpb": 0.9682386669191374,
+          "name": "paloma/mc4"
+        },
+        {
+          "bytes": 32768,
+          "delta_bits": 2390.1959502818445,
+          "documents": 1,
+          "gap_bpb": 0.0729429916467848,
+          "model_a_bpb": 1.207461719087488,
+          "model_b_bpb": 1.1345187274407031,
+          "name": "paloma/ptb"
+        },
+        {
+          "bytes": 887837,
+          "delta_bits": -2675.557794240517,
+          "documents": 256,
+          "gap_bpb": -0.0030135687003813956,
+          "model_a_bpb": 0.957047774756307,
+          "model_b_bpb": 0.9600613434566884,
+          "name": "paloma/redpajama"
+        },
+        {
+          "bytes": 9649,
+          "delta_bits": -110.72716778010506,
+          "documents": 256,
+          "gap_bpb": -0.011475507076391861,
+          "model_a_bpb": 2.7321562797220116,
+          "model_b_bpb": 2.7436317867984035,
+          "name": "paloma/twitterAAE_HELM_fixed"
+        },
+        {
+          "bytes": 987693,
+          "delta_bits": -2223.977491867736,
+          "documents": 59,
+          "gap_bpb": -0.0022516890287444945,
+          "model_a_bpb": 0.959892212278204,
+          "model_b_bpb": 0.9621439013069485,
+          "name": "paloma/wikitext_103"
+        },
+        {
+          "bytes": 1223044,
+          "delta_bits": -757.5955381563381,
+          "documents": 256,
+          "gap_bpb": -0.0006194344096830025,
+          "model_a_bpb": 1.1140732333314185,
+          "model_b_bpb": 1.1146926677411015,
+          "name": "uncheatable_eval/ao3_english"
+        },
+        {
+          "bytes": 1237838,
+          "delta_bits": -2641.362618716223,
+          "documents": 256,
+          "gap_bpb": -0.0021338516176722827,
+          "model_a_bpb": 0.8392149997443071,
+          "model_b_bpb": 0.8413488513619795,
+          "name": "uncheatable_eval/arxiv_computer_science"
+        },
+        {
+          "bytes": 1282105,
+          "delta_bits": -6874.422348763568,
+          "documents": 256,
+          "gap_bpb": -0.0053618247715776545,
+          "model_a_bpb": 0.898780342903204,
+          "model_b_bpb": 0.9041421676747816,
+          "name": "uncheatable_eval/arxiv_physics"
+        },
+        {
+          "bytes": 841249,
+          "delta_bits": -2576.7140924075557,
+          "documents": 256,
+          "gap_bpb": -0.0030629624432332823,
+          "model_a_bpb": 0.9210353556774373,
+          "model_b_bpb": 0.9240983181206707,
+          "name": "uncheatable_eval/bbc_news"
+        },
+        {
+          "bytes": 876685,
+          "delta_bits": -20735.435526858666,
+          "documents": 256,
+          "gap_bpb": -0.023652093427922988,
+          "model_a_bpb": 0.6159249412691202,
+          "model_b_bpb": 0.6395770346970432,
+          "name": "uncheatable_eval/github_cpp"
+        },
+        {
+          "bytes": 1006410,
+          "delta_bits": -18348.522751146724,
+          "documents": 256,
+          "gap_bpb": -0.01823165782449173,
+          "model_a_bpb": 0.5642952112385489,
+          "model_b_bpb": 0.5825268690630405,
+          "name": "uncheatable_eval/github_python"
+        },
+        {
+          "bytes": 635606,
+          "delta_bits": 181.41220324352676,
+          "documents": 256,
+          "gap_bpb": 0.00028541612766954175,
+          "model_a_bpb": 0.9594561202658204,
+          "model_b_bpb": 0.9591707041381508,
+          "name": "uncheatable_eval/wikipedia_english"
+        }
+      ],
+      "documents": 5140,
+      "examples": {
+        "model_a_worse": [
+          {
+            "bytes": 32768,
+            "dataset": "paloma/ptb",
+            "gap_bpb": 0.0729429916467848,
+            "model_a_bpb": 1.207461719087488,
+            "model_b_bpb": 1.1345187274407031,
+            "preview": "\u2026d\u2420it\u2420plans\u2420a\u2420public\u2420offering\u2420of\u2420N\u2420million\u2420shares\u2420of\u2420its\u2420berlitz\u2420international\u2420inc.\u2420unit\u2420at\u2420$\u2420N\u2420to\u2420$\u2420N\u2420a\u2420share\u2420\u23ce\u2420the\u2420of\u2026",
+            "row_index": 0,
+            "shard": "val_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": 1.9055144471099723,
+            "worst_text": "berlitz"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/mc4",
+            "gap_bpb": 0.0638529549788114,
+            "model_a_bpb": 1.051095312161513,
+            "model_b_bpb": 0.9872423571827015,
+            "preview": "\u2026ript\u2420in\u2420your\u2420choice\u2420of\u2420many\u2420assorted\u2420colors\u2420&\u2420more\u24208.7yd-Rosewood\u2420from\u2420Walmart\u2420Canada\u2420the\u2420use\u2420cookies!\u2420Avoid\u2420tangles\u2420o\u2026",
+            "row_index": 160,
+            "shard": "0_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": 4.397244193362861,
+            "worst_text": "yd-Rosewood"
+          },
+          {
+            "bytes": 17096,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "gap_bpb": 0.08691922340100618,
+            "model_a_bpb": 1.4391247143264443,
+            "model_b_bpb": 1.3522054909254382,
+            "preview": "\u2026\u2420am{\"\u0627\u0645\u06c1\u0627\u0631\u06cc\"}\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420ar{\"\u0639\u0631\u0628\u06cc\"}\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420ar_001{\"\u0645\u0627\u0688\u0631\u0646\u2420\u0627\u0633\u0679\u06cc\u0646\u0688\u0631\u0688\u2420\u0639\u0631\u0628\u06cc\"}\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420arn{\"\u0645\u0627\u067e\u0648\u0686\u06d2\"}\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420as{\"\u0622\u0633\u0627\u0645\u06cc\"}\u23ce\u2420\u2420\u2420\u2420\u2420\u2026",
+            "row_index": 31,
+            "shard": "00_text_jsonl_gz",
+            "worst_bucket": "text/non_ascii_word",
+            "worst_gap_bpb": 1.841851206654688,
+            "worst_text": "\u0627\u0633\u0679\u06cc\u0646\u0688\u0631\u0688"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "gap_bpb": 0.04089266504531696,
+            "model_a_bpb": 0.31525313201847666,
+            "model_b_bpb": 0.2743604669731597,
+            "preview": "\u2026verifyPixels\u2420(bitmap,\u2420bpp4indexedPixelsModified);\u23ce\u21e5GdipDisposeImage\u2420((GpImage\u2420*)\u2420bitmap);\u23ce\u21e5\u23ce\u21e5//\u2420No\u2420scan0\u2420-\u2420PixelFormat\u2026",
+            "row_index": 7,
+            "shard": "02_c_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": 3.9468384537828105,
+            "worst_text": "GdipDisposeImage"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/mc4",
+            "gap_bpb": 0.03282258586515639,
+            "model_a_bpb": 0.539224215596629,
+            "model_b_bpb": 0.5064016297314727,
+            "preview": "\u2026.,\u2420cf.\u2420\u2420Patent\u2420Documents\u24201-4).\u23ce[Non-patent\u2420Document\u24201]\u2420ECOC-IOOC\u2420Proceedings\u2420Vol.\u24203,\u2420Paper\u2420We4.\u2420\u2420P.\u242014-15,\u24202003\u23ceThe\u2420in\u2026",
+            "row_index": 113,
+            "shard": "0_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": 3.7962048501760015,
+            "worst_text": "ECOC-IOOC"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/m2d2_s2orc_unsplit",
+            "gap_bpb": 0.026741389976066808,
+            "model_a_bpb": 1.003889648418885,
+            "model_b_bpb": 0.9771482584428182,
+            "preview": "\u2026\u2420any\u2420instability\u2420to\u2420exist:\u23cewhere\u2420\u2340\u2420max\u2420is\u2420the\u2420largest\u2420\u0351positive\u0352\u2420eigenvalue\u2420of\u2420the\u2420stability\u2420operator,\u2420Eq.\u2420\u03517\u0352.\u23ceLike\u2420t\u2026",
+            "row_index": 0,
+            "shard": "cond-mat_stat-mech_jsonl_gz",
+            "worst_bucket": "text/non_ascii_word",
+            "worst_gap_bpb": 1.7763516451943138,
+            "worst_text": "\u0351positive\u0352"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/m2d2_s2orc_unsplit",
+            "gap_bpb": 0.025694846849349518,
+            "model_a_bpb": 0.9612469613201403,
+            "model_b_bpb": 0.9355521144707908,
+            "preview": "\u2026cative\u2420factor\u2420\u2423.\u2420The\u2420reason\u2420for\u2420the\u2420multiplicative\u2420factor\u2420\u0351of\u2420order\u2420unity\u0352\u2420is\u2420due\u2420to\u2420the\u2420fact\u2420that\u2420the\u2420two\u2420definitions\u2026",
+            "row_index": 0,
+            "shard": "nlin_CD_jsonl_gz",
+            "worst_bucket": "text/non_ascii_word",
+            "worst_gap_bpb": 5.624194018763305,
+            "worst_text": "\u0351of"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/m2d2_s2orc_unsplit",
+            "gap_bpb": 0.021747919803249263,
+            "model_a_bpb": 0.9733813593516627,
+            "model_b_bpb": 0.9516334395484134,
+            "preview": "\u2026ty\u2420(dashed\u2420blue\u2420line)\u2420gives\u2420slightly\u2420better\u2420Mean\u2420User\u2420Throughputs\u2420(MUTs)\u2420than\u2420the\u2420approximated\u2420PF\u2420utility\u2420(red\u2420stars\u2420c\u2026",
+            "row_index": 0,
+            "shard": "cs_NI_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": 1.9782717486552364,
+            "worst_text": "Throughputs"
+          }
+        ],
+        "model_b_worse": [
+          {
+            "bytes": 32768,
+            "dataset": "paloma/mc4",
+            "gap_bpb": -0.03349543327351491,
+            "model_a_bpb": 0.6788789149648373,
+            "model_b_bpb": 0.7123743482383522,
+            "preview": "\u2026cal(\"Roboto-Thin\"),url(https://fonts.gstatic.com/s/roboto/v20/KFOkCnqEu92Fr1MmgVxMIzIFKw.woff2)\u2420format(\"woff2\");unicod\u2026",
+            "row_index": 155,
+            "shard": "0_jsonl_gz",
+            "worst_bucket": "text/url",
+            "worst_gap_bpb": -2.7595931233848865,
+            "worst_text": "https://fonts.gstatic.com/s/rob\u2026"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "gap_bpb": -0.03142922486384718,
+            "model_a_bpb": 0.9001592718656448,
+            "model_b_bpb": 0.9315884967294921,
+            "preview": "\u2026NLINE3140\u23ceTIME22:9ONLINE3140\u23ceTIME22:9ONLINE3124\u23ce1627481417272:224664194:\u611f\u8c22\u8d85\u7ea7\u65e0\u654c\u6027\u611flogos\u8001\u677f\u7684\u793c\u7269\u2014\u2014\u23ceTIME22:10ONLINE3124\u23ce16274\u2026",
+            "row_index": 22,
+            "shard": "00_text_jsonl_gz",
+            "worst_bucket": "text/number",
+            "worst_gap_bpb": -2.2090915585670343,
+            "worst_text": "1627481417272:224664194"
+          },
+          {
+            "bytes": 10233,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "gap_bpb": -0.09790474013196251,
+            "model_a_bpb": 1.2327610565219858,
+            "model_b_bpb": 1.3306657966539484,
+            "preview": "\u2026\uff0c\u4e5f\u9020\u6210\u4e86\u4ea7\u4e1a\u7ed3\u6784\u7684\u4e25\u91cd\u5931\u8861\u3002\u5b9e\u884c\u4ea7\u4e1a\u7ed3\u6784\u975e\u5747\u8861\u534f\u8c03\u53d1\u5c55\u653f\u7b56\uff0c\u6b63\u662f\u21b5\u23ce\u7531\u524d\u4e00\u65f6\u671f\u6211\u56fd\u4ea7\u4e1a\u7ed3\u6784\u53d8\u52a8\u7684\u8d85\u524d\u6027\u6240\u9057\u7559\u4e0b\u7684\u7ed3\u6784\u7f3a\u9677\u548c\u73b0\u9636\u6bb5\u6211\u56fd\u4ea7\u4e1a\u7ed3\u6784\u52a8\u6001\u53d8\u5316\u7684\u5ba2\u89c2\u5b9e\u9645\u51b3\u5b9a\u7684\u3002\u4ea7\u4e1a\u7ed3\u6784\u975e\u5747\u8861\u534f\u8c03\u653f\u7b56\u7684\u4e3b\u21b5\u23ce\u8981\u5185\u5bb9\u662f\uff1a\u4ee5\u652f\u914d\u4ea7\u4e1a\u7684\u53d1\u5c55\u6765\u5e26\u52a8\u4ece\u5c5e\u4ea7\u2026",
+            "row_index": 17,
+            "shard": "00_text_jsonl_gz",
+            "worst_bucket": "text/non_ascii_word",
+            "worst_gap_bpb": -0.4319464019341469,
+            "worst_text": "\u7531\u524d\u4e00\u65f6\u671f\u6211\u56fd\u4ea7\u4e1a\u7ed3\u6784\u53d8\u52a8\u7684\u8d85\u524d\u6027\u6240\u9057\u7559\u4e0b\u7684\u7ed3\u6784\u7f3a\u9677\u548c\u73b0\u9636\u6bb5\u6211\u2026"
+          },
+          {
+            "bytes": 13225,
+            "dataset": "paloma/manosphere_meta_sep",
+            "gap_bpb": -0.06767422870421086,
+            "model_a_bpb": 1.1046976468087708,
+            "model_b_bpb": 1.1723718755129817,
+            "preview": "\u2026There\u2420is\u2420no\u2420point\u2420in\u2420not\u2420trying\u2420\u23ce\u23ce\u23ceblackpill_incel:\u23ce\u2420_incelinside\u2420said:\u2420\u21e5\u21e5\u21e5This\u2420is\u2420why\u2420I\u2420hate\u2420the\u2420cucks\u2420over\u2420at\u2420incelt\u2026",
+            "row_index": 80,
+            "shard": "incels_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": -2.8181955428443666,
+            "worst_text": "_incelinside"
+          },
+          {
+            "bytes": 9701,
+            "dataset": "paloma/redpajama",
+            "gap_bpb": -0.08800469206503099,
+            "model_a_bpb": 0.9716555142522304,
+            "model_b_bpb": 1.0596602063172613,
+            "preview": "\u2026te\u2420towels\u2420towels\u2420online\u2420choosing\u2420the\u2420best\u2420bath\u2420towels\u2420lovetoknow\u2420bath\u2420towels.\u23cefrette\u2420towels\u2420medium\u2420size\u2420of\u2420frette\u2420towe\u2026",
+            "row_index": 50,
+            "shard": "c4_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": -1.9169809186330073,
+            "worst_text": "lovetoknow"
+          },
+          {
+            "bytes": 23603,
+            "dataset": "paloma/manosphere_meta_sep",
+            "gap_bpb": -0.033532036887228917,
+            "model_a_bpb": 0.9655551086911847,
+            "model_b_bpb": 0.9990871455784136,
+            "preview": "\u2026ey\u2420want\u2420me\u2420to,\u2420something\u2420to\u2420do\u2420with\u2420my\u2420subconscious\u2420mind.\u2420\u21e5\u21e5\u2420Click\u2420to\u2420expand...\u2420BRO\u2420GET\u2420HELP\u2420ASAP\u2420FAST!!!\u2420please\u2420for\u2420t\u2026",
+            "row_index": 26,
+            "shard": "incels_jsonl_gz",
+            "worst_bucket": "whitespace/tab_or_cr",
+            "worst_gap_bpb": -7.297542588624356,
+            "worst_text": "\u2420\u21e5\u21e5\u2420"
+          },
+          {
+            "bytes": 29024,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "gap_bpb": -0.0266051636965986,
+            "model_a_bpb": 0.6013812030302139,
+            "model_b_bpb": 0.6279863667268125,
+            "preview": "\u2026201~\u21b5\u23ce~03003~^~315~^~S2113~\u21b5\u23ce~03003~^~341~^~S2113~\u21b5\u23ce~03003~^~406~^~S2113~\u21b5\u23ce~03003~^~629~^~S2113~\u21b5\u23ce~03003~^~653~^~S2113\u2026",
+            "row_index": 26,
+            "shard": "00_text_jsonl_gz",
+            "worst_bucket": "text/punctuation",
+            "worst_gap_bpb": -9.853113199684545,
+            "worst_text": "~^~"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/4chan",
+            "gap_bpb": -0.023415695477134398,
+            "model_a_bpb": 1.0838187501043501,
+            "model_b_bpb": 1.1072344455814844,
+            "preview": "\u2026ut\u2420through\u2420steel?\u23ce\u23ce\u23ceAnonymous\u242001/04/19(Fri)17:17:20\u2420no.198734593:\u23ce>>198729141\u23ce>BA\u2420in\u2420Econ\u23ce>knows\u2420more\u2420about\u2420economics\u23ce\u2026",
+            "row_index": 0,
+            "shard": "0_jsonl_gz",
+            "worst_bucket": "text/number",
+            "worst_gap_bpb": -3.8554126963397874,
+            "worst_text": "198734593"
+          }
+        ]
+      },
+      "label": "Gemma 3 tokenizer, 262k vocab",
+      "losses": 3,
+      "model": "gemma3-262k",
+      "overall_gap_bpb": -0.004075799754326137,
+      "paloma_gap_bpb": -0.0026511802974370792,
+      "pattern_buckets": [
+        {
+          "bytes": 110850,
+          "delta_bits": -3429.415712167521,
+          "documents": 33576,
+          "gap_bpb": -0.030937444403856755,
+          "model_a_bpb": 1.3836237203007107,
+          "model_b_bpb": 1.4145611647045673,
+          "name": "text/non_ascii"
+        },
+        {
+          "bytes": 243363,
+          "delta_bits": 4035.0901510693548,
+          "documents": 36486,
+          "gap_bpb": 0.016580540801474978,
+          "model_a_bpb": 1.3288441539758196,
+          "model_b_bpb": 1.3122636131743446,
+          "name": "text/non_ascii_word"
+        },
+        {
+          "bytes": 581666,
+          "delta_bits": -40617.73483968098,
+          "documents": 173710,
+          "gap_bpb": -0.06982999666420417,
+          "model_a_bpb": 1.3601061988725118,
+          "model_b_bpb": 1.429936195536716,
+          "name": "text/number"
+        },
+        {
+          "bytes": 993004,
+          "delta_bits": -62033.93994450401,
+          "documents": 799744,
+          "gap_bpb": -0.06247098696934152,
+          "model_a_bpb": 1.2726852698996893,
+          "model_b_bpb": 1.3351562568690307,
+          "name": "text/punctuation"
+        },
+        {
+          "bytes": 97492,
+          "delta_bits": -3485.8196259131164,
+          "documents": 1923,
+          "gap_bpb": -0.03575492990104948,
+          "model_a_bpb": 0.9991025268625985,
+          "model_b_bpb": 1.034857456763648,
+          "name": "text/url"
+        },
+        {
+          "bytes": 17035730,
+          "delta_bits": 141768.9019521785,
+          "documents": 3430328,
+          "gap_bpb": 0.008321856589190983,
+          "model_a_bpb": 0.894102721890232,
+          "model_b_bpb": 0.8857808653010409,
+          "name": "text/word"
+        },
+        {
+          "bytes": 377098,
+          "delta_bits": -34804.911655451215,
+          "documents": 47781,
+          "gap_bpb": -0.09229672831850398,
+          "model_a_bpb": 0.26279585420473817,
+          "model_b_bpb": 0.3550925825232422,
+          "name": "whitespace/mixed"
+        },
+        {
+          "bytes": 35659,
+          "delta_bits": -13327.858927046198,
+          "documents": 13755,
+          "gap_bpb": -0.3737586283139235,
+          "model_a_bpb": 1.310495707463757,
+          "model_b_bpb": 1.6842543357776805,
+          "name": "whitespace/multi_newline"
+        },
+        {
+          "bytes": 30687,
+          "delta_bits": -2041.2514233098552,
+          "documents": 5586,
+          "gap_bpb": -0.06651844179326279,
+          "model_a_bpb": 0.7470533655386361,
+          "model_b_bpb": 0.8135718073318988,
+          "name": "whitespace/multi_space"
+        },
+        {
+          "bytes": 81421,
+          "delta_bits": 1973.9330021687706,
+          "documents": 81421,
+          "gap_bpb": 0.024243536706362864,
+          "model_a_bpb": 1.5754939580764802,
+          "model_b_bpb": 1.5512504213701175,
+          "name": "whitespace/newline"
+        },
+        {
+          "bytes": 3424589,
+          "delta_bits": -52524.62813471431,
+          "documents": 3424589,
+          "gap_bpb": -0.015337498349353546,
+          "model_a_bpb": 1.0234525126833116,
+          "model_b_bpb": 1.038790011032665,
+          "name": "whitespace/single_space"
+        },
+        {
+          "bytes": 97401,
+          "delta_bits": -29699.858334013687,
+          "documents": 20609,
+          "gap_bpb": -0.3049235463087,
+          "model_a_bpb": 0.32979544856455445,
+          "model_b_bpb": 0.6347189948732544,
+          "name": "whitespace/tab_or_cr"
+        }
+      ],
+      "ties": 0,
+      "top_literals": {
+        "model_a_worse": [
+          {
+            "bucket": "text/word",
+            "bytes": 67491,
+            "delta_bits": 4242.940712900793,
+            "documents": 22497,
+            "example_dataset": "paloma/m2d2_s2orc_unsplit",
+            "example_doc_preview": "\u2026ress\u2420the\u2420differences\u2420across\u2420these\u2420three\u2420disease\u2420domains.\u23ce\"The\u2420consequences\u2420of\u2420an\u2420act\u2420affect\u2420the\u2420probability\u2420of\u2420its\u2420occ\u2026",
+            "gap_bpb": 0.06286676316695253,
+            "model_a_bpb": 0.8970151959294257,
+            "model_a_token_boundaries": "|The|",
+            "model_b_bpb": 0.8341484327624732,
+            "model_b_token_boundaries": "|\u2026The|",
+            "name": "The"
+          },
+          {
+            "bucket": "whitespace/mixed",
+            "bytes": 5268,
+            "delta_bits": 2811.4600413786716,
+            "documents": 2634,
+            "example_dataset": "paloma/m2d2_s2orc_unsplit",
+            "example_doc_preview": "\u2026e\u2420tube.\u2420Now\u2420that\u2420we\u2420have\u2420derived\u2420a\u2420equation\u2420of\u2420motion\u2420(22)\u2420\u23cewhere\u2420u\u2420\u2261\u2420v/cs\u2420and\u2420y\u2420\u2261\u2420vv\u2420,\u2420the\u2420equation\u2420of\u2420motion\u2420can\u2420be\u2420\u2026",
+            "gap_bpb": 0.5336864163588975,
+            "model_a_bpb": 4.269829250677582,
+            "model_a_token_boundaries": "|\u2420|\u23ce|",
+            "model_b_bpb": 3.7361428343186853,
+            "model_b_token_boundaries": "|\u2420\u23ce|",
+            "name": "\u2420\u23ce"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 5345,
+            "delta_bits": 2575.044791146871,
+            "documents": 5345,
+            "example_dataset": "uncheatable_eval/github_cpp",
+            "example_doc_preview": "\u2026\u2420\u2420\u2420\u2420\u2420\u2420if\u2420(headers[\"Content-Encoding\"]\u2420==\u2420\"gzip\")\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420{\u23ce#ifdef\u2420IXWEBSOCKET_USE_ZLIB\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420std::string\u2420decompr\u2026",
+            "gap_bpb": 0.48176703295544826,
+            "model_a_bpb": 1.4757640926607083,
+            "model_a_token_boundaries": "|#|",
+            "model_b_bpb": 0.99399705970526,
+            "model_b_token_boundaries": "|#\u2026|",
+            "name": "#"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 16576,
+            "delta_bits": 2155.8681512515227,
+            "documents": 8288,
+            "example_dataset": "paloma/dolma_100_programing_languages",
+            "example_doc_preview": "\u2026can0\u2420(1,\u24202,\u24200,\u2420PixelFormat16bppARGB1555,\u2420NULL,\u2420&bitmap);\u23ce#if\u2420defined(USE_WINDOWS_GDIPLUS)\u23ce\u21e5assertEqualInt\u2420(status,\u2420Ok)\u2026",
+            "gap_bpb": 0.13005961337183414,
+            "model_a_bpb": 1.3748870834413236,
+            "model_a_token_boundaries": "|if|",
+            "model_b_bpb": 1.2448274700694897,
+            "model_b_token_boundaries": "|\u2026if|",
+            "name": "if"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 28274,
+            "delta_bits": 2071.6814218088484,
+            "documents": 28274,
+            "example_dataset": "uncheatable_eval/github_cpp",
+            "example_doc_preview": "\u2026cter->getGold()\u2420+\u24203);\u21b5\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420break;\u21b5\u23ce\u21b5\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420case\u24203:\u2420{\u21b5\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420std::cout\u2420<<\u2420\"\\n\u2420[HealthPotion\u2420\ub2f9\ucca8!\u2420\ucd95\ud558\ub4dc\ub9bd\ub2c8\ub2e4!\u2026",
+            "gap_bpb": 0.07327160719420132,
+            "model_a_bpb": 1.5031591529319785,
+            "model_a_token_boundaries": "|:|",
+            "model_b_bpb": 1.4298875457377773,
+            "model_b_token_boundaries": "|:|",
+            "name": ":"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 16004,
+            "delta_bits": 2032.0462539887226,
+            "documents": 8002,
+            "example_dataset": "uncheatable_eval/github_cpp",
+            "example_doc_preview": "\u2026he\u2420License,\u2420or\u23ce\u2420\u2420\u2420(at\u2420your\u2420option)\u2420any\u2420later\u2420version.\u23ce\u23ce\u2420\u2420\u2420In\u2420addition\u2420to\u2420the\u2420permissions\u2420in\u2420the\u2420GNU\u2420General\u2420Public\u2420Lic\u2026",
+            "gap_bpb": 0.12697114808727333,
+            "model_a_bpb": 1.6233639610752293,
+            "model_a_token_boundaries": "|In|",
+            "model_b_bpb": 1.496392812987956,
+            "model_b_token_boundaries": "|\u2026In|",
+            "name": "In"
+          },
+          {
+            "bucket": "whitespace/newline",
+            "bytes": 81421,
+            "delta_bits": 1973.9330021687706,
+            "documents": 81421,
+            "example_dataset": "paloma/redpajama",
+            "example_doc_preview": "\u2026hics[width=15.0cm]{eps/fig5_FlattenedCN-AC5a.eps}\u21b5\u23ce\\caption\u23ce\\label{Fig:Structure_of_Flattened_Armchair_Nanotube}\u21b5\u23ceSome\u2026",
+            "gap_bpb": 0.024243536706362864,
+            "model_a_bpb": 1.5754939580764802,
+            "model_a_token_boundaries": "|\u23ce|",
+            "model_b_bpb": 1.5512504213701175,
+            "model_b_token_boundaries": "|\u23ce|",
+            "name": "\u23ce"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 1224,
+            "delta_bits": 1664.8926728169536,
+            "documents": 408,
+            "example_dataset": "paloma/ptb",
+            "example_doc_preview": "\u2026e\u2420their\u2420pockets\u2420with\u2420literally\u2420millions\u2420of\u2420dollars\u2420while\u2420<unk>\u2420severe\u2420pay\u2420cuts\u2420on\u2420the\u2420<unk>\u2420employees\u2420of\u2420united\u2420is\u2420not\u2026",
+            "gap_bpb": 1.3602064320399947,
+            "model_a_bpb": 1.3927001135654056,
+            "model_a_token_boundaries": "|\u2026unk\u2026|",
+            "model_b_bpb": 0.03249368152541068,
+            "model_b_token_boundaries": "|unk|",
+            "name": "unk"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 516924,
+            "delta_bits": 1571.5093812638027,
+            "documents": 172308,
+            "example_dataset": "uncheatable_eval/bbc_news",
+            "example_doc_preview": "\u2026e\u2420driver\u2420Affan\u2420Kurniawan.\u23cePresident\u2420Prabowo\u2420Subianto\u2420and\u2420\u2420the\u2420chief\u2420of\u2420police\u2420apologised\u2420for\u2420his\u2420death\u2420-\u2420but\u2420it\u2420fuelle\u2026",
+            "gap_bpb": 0.0030401168861647026,
+            "model_a_bpb": 0.4703131232883434,
+            "model_a_token_boundaries": "|the|",
+            "model_b_bpb": 0.46727300640217867,
+            "model_b_token_boundaries": "|\u2026the|",
+            "name": "the"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 6594,
+            "delta_bits": 1550.6648956826107,
+            "documents": 3297,
+            "example_dataset": "uncheatable_eval/github_cpp",
+            "example_doc_preview": "//\u23ce//\u2420Created\u2420by\u2420DexrnZacAttack\u2420on\u24209/12/25\u2420using\u2420zPc-i2.\u23ce//\u23ce#include\u2420\"FSEditScreen.h\"\u23ce\u23ce#include\u2420<QFileDialog>\u23ce#include\u2026",
+            "gap_bpb": 0.23516301117419028,
+            "model_a_bpb": 0.7965849290376285,
+            "model_a_token_boundaries": "|//|",
+            "model_b_bpb": 0.5614219178634381,
+            "model_b_token_boundaries": "|//|",
+            "name": "//"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 918,
+            "delta_bits": 1523.7862012465541,
+            "documents": 306,
+            "example_dataset": "paloma/wikitext_103",
+            "example_doc_preview": "\u2026er\u24201283\u2420.\u2420The\u2420Mongol\u2420sources\u2420say\u2420that\u2420the\u2420Burmese\u2420lost\u242010\u2420@,@\u2420000\u2420men\u2420at\u2420Kaungsin\u2420.\u2420The\u2420Mongol\u2420armies\u2420pushed\u2420farther\u2420s\u2026",
+            "gap_bpb": 1.6598978227086647,
+            "model_a_bpb": 4.453380175921624,
+            "model_a_token_boundaries": "|\u2026@|,@|",
+            "model_b_bpb": 2.7934823532129593,
+            "model_b_token_boundaries": "|\u2026@|,@|",
+            "name": "@,@"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 70450,
+            "delta_bits": 1453.6397496658817,
+            "documents": 70450,
+            "example_dataset": "paloma/m2d2_wikipedia_unsplit",
+            "example_doc_preview": "\u2026ially,\u2420the\u2420Germans\u2420secured\u2420the\u2420area.\u2420On\u2420September\u242020,\u24201941,a\u2420small\u2420group\u2420of\u2420Soviet\u2420soldiers\u2420under\u2420Captain\u2420Vasily\u2420Dubik\u2026",
+            "gap_bpb": 0.02063363732669811,
+            "model_a_bpb": 1.462324574106176,
+            "model_a_token_boundaries": "|a|",
+            "model_b_bpb": 1.441690936779478,
+            "model_b_token_boundaries": "|\u2026a|",
+            "name": "a"
+          }
+        ],
+        "model_b_worse": [
+          {
+            "bucket": "whitespace/single_space",
+            "bytes": 3424589,
+            "delta_bits": -52524.62813471431,
+            "documents": 3424589,
+            "example_dataset": "paloma/dolma_100_programing_languages",
+            "example_doc_preview": "\u2026{\"\u062c\u0631\u0645\u0646\"}\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420de_AT{\"\u0622\u0633\u0679\u0631\u06cc\u0627\u0626\u06cc\u2420\u062c\u0631\u0645\u0646\"}\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420de_CH{\"\u0633\u0648\u0626\u0633\u2420\u06c1\u0627\u0626\u06cc\u2420\u062c\u0631\u0645\u0646\"}\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420dje{\"\u0632\u0631\u0645\u0627\"}\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420dsb{\"\u0630\u06cc\u0644\u06cc\u2420\u0633\u0631\u0628\u06cc\u0627\u0626\u06cc\"\u2026",
+            "gap_bpb": -0.015337498349353546,
+            "model_a_bpb": 1.0234525126833116,
+            "model_a_token_boundaries": "|\u2420\u2026|",
+            "model_b_bpb": 1.038790011032665,
+            "model_b_token_boundaries": "|\u2420|",
+            "name": "\u2420"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 178473,
+            "delta_bits": -50525.51569124215,
+            "documents": 178473,
+            "example_dataset": "uncheatable_eval/github_python",
+            "example_doc_preview": "\u2026\u2420\u2420\u2420\u2420st.error(\"Please\u2420type\u2420'DELETE'\u2420to\u2420confirm\")\u23ce\u2420\u2420\u2420\u2420\u23ce\u2420\u2420\u2420\u2420#\u2420About\u2420section\u23ce\u2420\u2420\u2420\u2420with\u2420st.expander(\"\u2139\ufe0f\u2420About\"):\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420st.",
+            "gap_bpb": -0.2830989320022757,
+            "model_a_bpb": 1.3779584924601236,
+            "model_a_token_boundaries": "|.|",
+            "model_b_bpb": 1.661057424462399,
+            "model_b_token_boundaries": "|.|",
+            "name": "."
+          },
+          {
+            "bucket": "whitespace/multi_newline",
+            "bytes": 23724,
+            "delta_bits": -12476.37023167992,
+            "documents": 7908,
+            "example_dataset": "paloma/4chan",
+            "example_doc_preview": "\u2026ymous\u242008/27/17(Sun)14:48:38\u2420no.139250595:\u23ce>>139242946\u23ceRoll\u23ce\u23ce\u23ceAnonymous\u242008/27/17(Sun)14:49:34\u2420no.139250684:\u23ce>>139250406\u2026",
+            "gap_bpb": -0.5258965702107538,
+            "model_a_bpb": 1.535280026178675,
+            "model_a_token_boundaries": "|\u23ce\u23ce\u23ce|",
+            "model_b_bpb": 2.0611765963894286,
+            "model_b_token_boundaries": "|\u23ce\u23ce\u23ce|",
+            "name": "\u23ce\u23ce\u23ce"
+          },
+          {
+            "bucket": "whitespace/mixed",
+            "bytes": 50145,
+            "delta_bits": -7907.376397565821,
+            "documents": 10029,
+            "example_dataset": "uncheatable_eval/github_python",
+            "example_doc_preview": "\u2026:\u2420Optional[str]\u23ce)\u2420->\u2420Dict[str,\u2420Union[str,\u2420None]]:\u23ce\u2420\u2420\u2420\u2420\"\"\"\u23ce\u2420\u2420\u2420\u2420\u751f\u6210\u6587\u4ef6\u5143\u6570\u636e\u23ce\u23ce\u2420\u2420\u2420\u2420Args:\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420mime_type:\u2420\u6587\u4ef6MIME\u7c7b\u578b\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420o\u2026",
+            "gap_bpb": -0.15769022629506074,
+            "model_a_bpb": 0.1206390827950847,
+            "model_a_token_boundaries": "|\u23ce|\u2420\u2420\u2420\u2420|",
+            "model_b_bpb": 0.2783293090901454,
+            "model_b_token_boundaries": "|\u2026\u23ce|\u2420\u2420\u2420|\u2420|",
+            "name": "\u23ce\u2420\u2420\u2420\u2420"
+          },
+          {
+            "bucket": "whitespace/mixed",
+            "bytes": 6724,
+            "delta_bits": -7765.653647936882,
+            "documents": 1681,
+            "example_dataset": "paloma/manosphere_meta_sep",
+            "example_doc_preview": "\u2026FL\u2420IF\u2420AN\u2420INCEL\u2420IS\u2420INTO\u2420A\u2420FOID\u2420MAKING\u2420HIM\u2420WORSHIP\u2420HER\u2420FOOT\u2420\u23ce\u23ce\u23ceacnescarcel:\u23ce\u2420nice\u2420larp\u2420br0.\u2420incels\u2420going\u2420to\u2420underground\u2420\u2026",
+            "gap_bpb": -1.154915771555158,
+            "model_a_bpb": 1.3476220227692512,
+            "model_a_token_boundaries": "|\u2420|\u23ce\u23ce\u23ce|",
+            "model_b_bpb": 2.502537794324409,
+            "model_b_token_boundaries": "|\u2420\u23ce\u23ce\u23ce|",
+            "name": "\u2420\u23ce\u23ce\u23ce"
+          },
+          {
+            "bucket": "whitespace/mixed",
+            "bytes": 78705,
+            "delta_bits": -6806.12695932433,
+            "documents": 8745,
+            "example_dataset": "uncheatable_eval/github_python",
+            "example_doc_preview": "\u2026)\u23ce\u2420\u2420\u2420\u2420parser.add_argument('--model',\u2420type=str,\u2420help=\"\"\"\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420FLUX.1-schnell,\u2420FLUX.1-dev,\u2420FLUX.1-Krea-dev\u2420|\u2420SD-3-Med\u2026",
+            "gap_bpb": -0.08647642410678266,
+            "model_a_bpb": 0.06383074529826104,
+            "model_a_token_boundaries": "|\u23ce|\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420|",
+            "model_b_bpb": 0.1503071694050437,
+            "model_b_token_boundaries": "|\u2026\u23ce|\u2420\u2420\u2420\u2420\u2420\u2420\u2420|\u2420\u2026|",
+            "name": "\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420"
+          },
+          {
+            "bucket": "text/number",
+            "bytes": 16821,
+            "delta_bits": -4555.715768420263,
+            "documents": 16821,
+            "example_dataset": "paloma/dolma_100_programing_languages",
+            "example_doc_preview": "\u2026age\u2420*)(plc->message);\u23ce\u23ce#ifndef\u2420__GNUC__\u23ce#pragma\u2420pack\u2420(push,1)\u23ce#endif\u23ce\u23ce\u21e5struct\u2420__packed\u2420vs_forward_config_request\u23ce\u21e5{\u23ce\u21e5\u21e5\u2026",
+            "gap_bpb": -0.2708350138767174,
+            "model_a_bpb": 1.3841182183761673,
+            "model_a_token_boundaries": "|1|",
+            "model_b_bpb": 1.6549532322528848,
+            "model_b_token_boundaries": "|1|",
+            "name": "1"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 59323,
+            "delta_bits": -4352.945918478504,
+            "documents": 59323,
+            "example_dataset": "paloma/m2d2_s2orc_unsplit",
+            "example_doc_preview": "\u2026we\u2420decompose\u2420the\u2420weighting\u2420function\u2420w(x)\u2420into\u2420coarse-scalew(x)\u2420and\u2420fine-scale\u2420w\u2420\u2032\u2420(x)\u2420components.\u23ceWe\u2420further\u2420make\u2420an\u2420a\u2026",
+            "gap_bpb": -0.07337703619976238,
+            "model_a_bpb": 1.37561652526476,
+            "model_a_token_boundaries": "|(|",
+            "model_b_bpb": 1.4489935614645226,
+            "model_b_token_boundaries": "|(\u2026|",
+            "name": "("
+          },
+          {
+            "bucket": "whitespace/tab_or_cr",
+            "bytes": 2808,
+            "delta_bits": -3766.086983580051,
+            "documents": 702,
+            "example_dataset": "paloma/manosphere_meta_sep",
+            "example_doc_preview": "\u2026ey\u2420want\u2420me\u2420to,\u2420something\u2420to\u2420do\u2420with\u2420my\u2420subconscious\u2420mind.\u2420\u21e5\u21e5\u2420Click\u2420to\u2420expand...\u2420BRO\u2420GET\u2420HELP\u2420ASAP\u2420FAST!!!\u2420please\u2420for\u2420t\u2026",
+            "gap_bpb": -1.3411990682265138,
+            "model_a_bpb": 1.4102577823164273,
+            "model_a_token_boundaries": "|\u2420|\u21e5\u21e5|\u2420\u2026|",
+            "model_b_bpb": 2.751456850542941,
+            "model_b_token_boundaries": "|\u2420\u21e5\u21e5|\u2420\u2026|",
+            "name": "\u2420\u21e5\u21e5\u2420"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 183488,
+            "delta_bits": -3634.6824110612993,
+            "documents": 183488,
+            "example_dataset": "paloma/dolma-v1_5",
+            "example_doc_preview": "\u2026by\u2420the\u2420NTDP\u2420staff\u2420over\u2420the\u2420upcoming\u2420season.\u23ceJustin\u2420Cmunt,\u2420F,\u2420\u201998\u2420(MB36)\u2420\u2014\u2420No\u2420height\u2420or\u2420weight\u2420listed,\u2420but\u2420our\u2420guess\u2420is\u2026",
+            "gap_bpb": -0.019808828975525918,
+            "model_a_bpb": 1.7982970986148321,
+            "model_a_token_boundaries": "|,|",
+            "model_b_bpb": 1.8181059275903582,
+            "model_b_token_boundaries": "|,|",
+            "name": ","
+          },
+          {
+            "bucket": "whitespace/tab_or_cr",
+            "bytes": 7356,
+            "delta_bits": -3364.4768596325553,
+            "documents": 3678,
+            "example_dataset": "paloma/dolma_100_programing_languages",
+            "example_doc_preview": "\u2026301~^~S8522~\u21b5\u23ce~01252~^~628~^~S8522~\u21b5\u23ce~01252~^~601~^~S7181~\u21b5\u23ce~07081~^~608~^~S8522~\u21b5\u23ce~07081~^~611~^~S8522~\u21b5\u23ce~01252~^~421\u2026",
+            "gap_bpb": -0.4573785834193251,
+            "model_a_bpb": 0.4726703667657913,
+            "model_a_token_boundaries": "|\u21b5|\u23ce|",
+            "model_b_bpb": 0.9300489501851165,
+            "model_b_token_boundaries": "|\u21b5\u23ce|",
+            "name": "\u21b5\u23ce"
+          },
+          {
+            "bucket": "whitespace/mixed",
+            "bytes": 57564,
+            "delta_bits": -3182.0048134874883,
+            "documents": 4428,
+            "example_dataset": "uncheatable_eval/github_python",
+            "example_doc_preview": "\u2026/dg_wyymusic.php?id={song_id}&br=7&type=json\"\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420result\u2420=\u2420await\u2420self._request(url,\u2420method=\"GET\")\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420",
+            "gap_bpb": -0.05527768767784533,
+            "model_a_bpb": 0.04378512046888158,
+            "model_a_token_boundaries": "|\u23ce|\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420|",
+            "model_b_bpb": 0.09906280814672691,
+            "model_b_token_boundaries": "|\u2026\u23ce|\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420|",
+            "name": "\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420"
+          }
+        ]
+      },
+      "top_segments": {
+        "model_a_worse": [
+          {
+            "bucket": "text/url",
+            "bytes": 579,
+            "dataset": "paloma/mc4",
+            "delta_bits": 192.2429088424736,
+            "doc_preview": "\u2026om/cache/frvrrmdhtiqi.jpg?imgeng=/w_300','https://images.webfronts.com/cache/frehipicxepw.jpg?imgeng=/w_300','https://\u2026",
+            "gap_bpb": 0.33202574929615475,
+            "text": "https://images.webfronts.com/ca\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 67,
+            "dataset": "paloma/mc4",
+            "delta_bits": 139.55981457343714,
+            "doc_preview": "\u2026ions:\u2420[\u2420],\u2420image_urls:\u2420[\u2420'https://images.webfronts.com/cache/frjygiohwuib.jpg?imgeng=/w_300',\u2420'https://images.webfront\u2026",
+            "gap_bpb": 2.082982307066226,
+            "text": "https://images.webfronts.com/ca\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 67,
+            "dataset": "paloma/mc4",
+            "delta_bits": 136.7118152397846,
+            "doc_preview": "\u2026ions:\u2420[\u2420],\u2420image_urls:\u2420[\u2420'https://images.webfronts.com/cache/frskfdklvcqv.jpg?imgeng=/w_300',\u2420'https://images.webfront\u2026",
+            "gap_bpb": 2.0404748543251436,
+            "text": "https://images.webfronts.com/ca\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 206,
+            "dataset": "paloma/mc4",
+            "delta_bits": 127.88404569291025,
+            "doc_preview": "\u2026load/v1579732497/resources/flfe/lawyers-mobile-bg2.jpg);background-size:cover;background-position:50%;height:unset;wid\u2026",
+            "gap_bpb": 0.6207963383150983,
+            "text": "https://images.findlawresources\u2026"
+          },
+          {
+            "bucket": "text/non_ascii_word",
+            "bytes": 47,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": 108.66699510817048,
+            "doc_preview": "\u2026\"WHERE\u2420name\u2420=\u2420?\u2420AND\u2420age\u2420=\u2420?\":@[@\"John\",@\"17\"]}\u3002\u8981\u4fdd\u8bc1where\u5b57\u5178\u6709\u4e14\u4ec5\u6709\u4e00\u7ec4key-value\u23ce@return\u2420\u8bb0\u5f55\u6570\u76ee\u23ce*/\u23ce-\u2420(int)itemCountForTable:(NSS\u2026",
+            "gap_bpb": 2.312063725705755,
+            "text": "\u8981\u4fdd\u8bc1where\u5b57\u5178\u6709\u4e14\u4ec5\u6709\u4e00\u7ec4key-value"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 49,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": 94.68711067648054,
+            "doc_preview": "\u2026l_green)\u23ce-\u2420[all_seeing_eye\u24200.0.20](https://github.com/docker-rubygem/all_seeing_eye)\u23ce-\u2420[allegro_release\u24200.1.15](https:\u2026",
+            "gap_bpb": 1.9323900138057253,
+            "text": "https://github.com/docker-rubyg\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 39,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": 76.48616816154846,
+            "doc_preview": "\u2026bygem/ahoward-lockfile)\u23ce-\u2420[ahub\u24200.12.0](https://github.com/docker-rubygem/ahub)\u23ce-\u2420[aidir\u24200.0.7](https://github.com/doc\u2026",
+            "gap_bpb": 1.9611837990140633,
+            "text": "https://github.com/docker-rubyg\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 54,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": 75.50940765846441,
+            "doc_preview": "\u2026)\u23ce-\u2420[activerecord-search\u24200.2.2](https://github.com/docker-rubygem/activerecord-search)\u23ce-\u2420[activerecord-sharding\u24200.3.2]\u2026",
+            "gap_bpb": 1.3983223640456373,
+            "text": "https://github.com/docker-rubyg\u2026"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 27,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": 69.2222086538201,
+            "doc_preview": "\u2026uery_tree_reply_impl;\u23cetxcb_intern_atom_sizeof\u2420xcb_intern_atom_sizeof_impl;\u23cetxcb_intern_atom\u2420xcb_intern_atom_impl;\u23cetxcb\u2026",
+            "gap_bpb": 2.563785505697041,
+            "text": "xcb_intern_atom_sizeof_impl"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 65,
+            "dataset": "paloma/mc4",
+            "delta_bits": 68.18321571256094,
+            "doc_preview": "\u2026woff2)\u2420format(\"woff2\"),url(https://fonts.gstatic.com/s/roboto/v20/KFOmCnqEu92Fr1Mu4mxM.woff)\u2420format(\"woff\");unicode-ra\u2026",
+            "gap_bpb": 1.0489725494240145,
+            "text": "https://fonts.gstatic.com/s/rob\u2026"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 13,
+            "dataset": "paloma/manosphere_meta_sep",
+            "delta_bits": 67.92323332288308,
+            "doc_preview": "\u2026\u2420in\u2420general.\u2420I\u2420had\u2420a\u2420full\u2420block\u2420list\u2420at\u2420one\u2420point\u2420\u23ce\u23ce\u23cewhogivesafucc:\u23ce\u2420Captvic\u2420said:\u2420\u21e5\u21e5\u21e5Bunch\u2420of\u2420cope\u2420itt\u2420Those\u2420average\u2420\u2026",
+            "gap_bpb": 5.224864101760237,
+            "text": "whogivesafucc"
+          },
+          {
+            "bucket": "text/number",
+            "bytes": 23,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": 65.57666763798336,
+            "doc_preview": "\u2026NLINE2862\u23ceTIME1:25ONLINE2862\u23ceTIME1:25ONLINE2853\u23ce1627406743867:110767787:\u8349\u54c8\u54c8\u54c8\u54c8\u54c8\u54c8\u23ceTIME1:26ONLINE2853\u23ceTIME1:26ONLINE2846\u23ce\u2026",
+            "gap_bpb": 2.8511594625210157,
+            "text": "1627406743867:110767787"
+          }
+        ],
+        "model_b_worse": [
+          {
+            "bucket": "text/url",
+            "bytes": 67,
+            "dataset": "paloma/mc4",
+            "delta_bits": -199.9653208499782,
+            "doc_preview": "\u2026ions:\u2420[\u2420],\u2420image_urls:\u2420[\u2420'https://images.webfronts.com/cache/frskfdklvcqv.jpg?imgeng=/w_300',\u2420'https://images.webfront\u2026",
+            "gap_bpb": -2.984557027611615,
+            "text": "https://images.webfronts.com/ca\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 72,
+            "dataset": "paloma/mc4",
+            "delta_bits": -198.69070488371182,
+            "doc_preview": "\u2026cal(\"Roboto-Thin\"),url(https://fonts.gstatic.com/s/roboto/v20/KFOkCnqEu92Fr1MmgVxMIzIFKw.woff2)\u2420format(\"woff2\");unicod\u2026",
+            "gap_bpb": -2.7595931233848865,
+            "text": "https://fonts.gstatic.com/s/rob\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 89,
+            "dataset": "paloma/mc4",
+            "delta_bits": -167.44801268464636,
+            "doc_preview": "\u2026to-Black\"),url(https://fonts.gstatic.com/s/roboto/v16/s7gftie1JANC-QmDJvMWZoX0hVgzZQUfRDuZrPvH3D8.woff2)\u2420format(\"woff2\u2026",
+            "gap_bpb": -1.8814383447713074,
+            "text": "https://fonts.gstatic.com/s/rob\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 67,
+            "dataset": "paloma/mc4",
+            "delta_bits": -148.62846921247885,
+            "doc_preview": "\u2026ions:\u2420[\u2420],\u2420image_urls:\u2420[\u2420'https://images.webfronts.com/cache/frhtxpvaylak.jpg?imgeng=/w_300',\u2420'https://images.webfront\u2026",
+            "gap_bpb": -2.2183353613802814,
+            "text": "https://images.webfronts.com/ca\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 135,
+            "dataset": "paloma/mc4",
+            "delta_bits": -135.4035784711081,
+            "doc_preview": "\u2026images.webfronts.com/cache/frpccopatfdq.jpg?imgeng=/w_300','https://images.webfronts.com/cache/frrxvbnhshef.jpg?imgeng\u2026",
+            "gap_bpb": -1.0029894701563562,
+            "text": "https://images.webfronts.com/ca\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 89,
+            "dataset": "paloma/mc4",
+            "delta_bits": -129.88811889250542,
+            "doc_preview": "\u2026to-Black\"),url(https://fonts.gstatic.com/s/roboto/v16/mnpfi9pxYH-Go5UiibESIpBw1xU1rKptJj_0jans920.woff2)\u2420format(\"woff2\u2026",
+            "gap_bpb": -1.459417066207926,
+            "text": "https://fonts.gstatic.com/s/rob\u2026"
+          },
+          {
+            "bucket": "text/non_ascii_word",
+            "bytes": 57,
+            "dataset": "uncheatable_eval/github_cpp",
+            "delta_bits": -119.72767612105967,
+            "doc_preview": "\u2026\u2420\"\\nRandom\u2420\uc544\uc774\ud15c\uc744\u2420\uad6c\ub9e4\ud569\ub2c8\ub2e4!\\n\";\u21b5\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420std::cout\u2420<<\u2420\"\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\\n\";\u21b5\u23ce\u21b5\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420switch\u2420(random)\u21b5\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420{\u21b5\u23ce\u2420\u2420\u2420\u2420\u2420\u2026",
+            "gap_bpb": -2.1004855459835032,
+            "text": "\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137"
+          },
+          {
+            "bucket": "text/non_ascii_word",
+            "bytes": 47,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": -95.12180198602368,
+            "doc_preview": "\u2026\"WHERE\u2420name\u2420=\u2420?\u2420AND\u2420age\u2420=\u2420?\":@[@\"John\",@\"17\"]}\u3002\u8981\u4fdd\u8bc1where\u5b57\u5178\u6709\u4e14\u4ec5\u6709\u4e00\u7ec4key-value\u23ce@param\u2420block\u2420\u56de\u8c03\u23ce@return\u2420\u67e5\u8be2\u7ed3\u679c\u23ce*/\u23ce-\u2420(NSMutableA\u2026",
+            "gap_bpb": -2.023868127362206,
+            "text": "\u8981\u4fdd\u8bc1where\u5b57\u5178\u6709\u4e14\u4ec5\u6709\u4e00\u7ec4key-value"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 49,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": -94.92597660634196,
+            "doc_preview": "\u2026em/akane)\u23ce-\u2420[akane-bigquery\u24200.1.0](https://github.com/docker-rubygem/akane-bigquery)\u23ce-\u2420[akapen\u24200.0.1](https://github.c\u2026",
+            "gap_bpb": -1.9372648287008563,
+            "text": "https://github.com/docker-rubyg\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 89,
+            "dataset": "paloma/mc4",
+            "delta_bits": -80.90363653746265,
+            "doc_preview": "\u2026to-Black\"),url(https://fonts.gstatic.com/s/roboto/v16/3Y_xCyt7TNunMGg0Et2pnoX0hVgzZQUfRDuZrPvH3D8.woff2)\u2420format(\"woff2\u2026",
+            "gap_bpb": -0.9090296240164342,
+            "text": "https://fonts.gstatic.com/s/rob\u2026"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 36,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": -80.73614319274344,
+            "doc_preview": "\u2026y_impl;\u23cetxcb_list_fonts_with_info_sizeof\u2420xcb_list_fonts_with_info_sizeof_impl;\u23cetxcb_list_fonts_with_info\u2420xcb_list_font\u2026",
+            "gap_bpb": -2.242670644242873,
+            "text": "xcb_list_fonts_with_info_sizeof\u2026"
+          },
+          {
+            "bucket": "text/non_ascii_word",
+            "bytes": 144,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": -62.20028187851715,
+            "doc_preview": "\u2026\uff0c\u4e5f\u9020\u6210\u4e86\u4ea7\u4e1a\u7ed3\u6784\u7684\u4e25\u91cd\u5931\u8861\u3002\u5b9e\u884c\u4ea7\u4e1a\u7ed3\u6784\u975e\u5747\u8861\u534f\u8c03\u53d1\u5c55\u653f\u7b56\uff0c\u6b63\u662f\u21b5\u23ce\u7531\u524d\u4e00\u65f6\u671f\u6211\u56fd\u4ea7\u4e1a\u7ed3\u6784\u53d8\u52a8\u7684\u8d85\u524d\u6027\u6240\u9057\u7559\u4e0b\u7684\u7ed3\u6784\u7f3a\u9677\u548c\u73b0\u9636\u6bb5\u6211\u56fd\u4ea7\u4e1a\u7ed3\u6784\u52a8\u6001\u53d8\u5316\u7684\u5ba2\u89c2\u5b9e\u9645\u51b3\u5b9a\u7684\u3002\u4ea7\u4e1a\u7ed3\u6784\u975e\u5747\u8861\u534f\u8c03\u653f\u7b56\u7684\u4e3b\u21b5\u23ce\u8981\u5185\u5bb9\u662f\uff1a\u4ee5\u652f\u914d\u4ea7\u4e1a\u7684\u53d1\u5c55\u6765\u5e26\u52a8\u4ece\u5c5e\u4ea7\u2026",
+            "gap_bpb": -0.4319464019341469,
+            "text": "\u7531\u524d\u4e00\u65f6\u671f\u6211\u56fd\u4ea7\u4e1a\u7ed3\u6784\u53d8\u52a8\u7684\u8d85\u524d\u6027\u6240\u9057\u7559\u4e0b\u7684\u7ed3\u6784\u7f3a\u9677\u548c\u73b0\u9636\u6bb5\u6211\u2026"
+          }
+        ]
+      },
+      "uncheatable_gap_bpb": -0.007286090341615877,
+      "wins": 20
+    },
+    {
+      "baseline": "llama3-128k",
+      "biggest_losses": [
+        {
+          "bytes": 9649,
+          "delta_bits": 2093.282911536461,
+          "documents": 256,
+          "gap_bpb": 0.21694299010638005,
+          "model_a_bpb": 2.960574776904784,
+          "model_b_bpb": 2.7436317867984035,
+          "name": "paloma/twitterAAE_HELM_fixed"
+        },
+        {
+          "bytes": 37599,
+          "delta_bits": 2395.3202803267304,
+          "documents": 256,
+          "gap_bpb": 0.06370702094009761,
+          "model_a_bpb": 1.737756037745605,
+          "model_b_bpb": 1.6740490168055073,
+          "name": "paloma/gab"
+        },
+        {
+          "bytes": 204005,
+          "delta_bits": 1122.8878367318525,
+          "documents": 256,
+          "gap_bpb": 0.005504217233557278,
+          "model_a_bpb": 1.1354692380134255,
+          "model_b_bpb": 1.1299650207798682,
+          "name": "paloma/dolma_100_subreddits"
+        },
+        {
+          "bytes": 32768,
+          "delta_bits": 127.26609713038928,
+          "documents": 1,
+          "gap_bpb": 0.0038838530618404933,
+          "model_a_bpb": 1.1384025805025437,
+          "model_b_bpb": 1.1345187274407031,
+          "name": "paloma/ptb"
+        },
+        {
+          "bytes": 1223044,
+          "delta_bits": -754.6337854825156,
+          "documents": 256,
+          "gap_bpb": -0.0006170127857072318,
+          "model_a_bpb": 1.1140756549553943,
+          "model_b_bpb": 1.1146926677411015,
+          "name": "uncheatable_eval/ao3_english"
+        }
+      ],
+      "biggest_wins": [
+        {
+          "bytes": 876685,
+          "delta_bits": -11555.673369543541,
+          "documents": 256,
+          "gap_bpb": -0.013181100816762624,
+          "model_a_bpb": 0.6263959338802806,
+          "model_b_bpb": 0.6395770346970432,
+          "name": "uncheatable_eval/github_cpp"
+        },
+        {
+          "bytes": 1006410,
+          "delta_bits": -13238.543415350297,
+          "documents": 256,
+          "gap_bpb": -0.01315422483416331,
+          "model_a_bpb": 0.5693726442288772,
+          "model_b_bpb": 0.5825268690630405,
+          "name": "uncheatable_eval/github_python"
+        },
+        {
+          "bytes": 898445,
+          "delta_bits": -5917.87943259586,
+          "documents": 256,
+          "gap_bpb": -0.006586802122106372,
+          "model_a_bpb": 0.6539042328970067,
+          "model_b_bpb": 0.6604910350191131,
+          "name": "paloma/dolma_100_programing_languages"
+        },
+        {
+          "bytes": 1067444,
+          "delta_bits": -6485.3729138289955,
+          "documents": 256,
+          "gap_bpb": -0.006075609506286977,
+          "model_a_bpb": 1.157861498801976,
+          "model_b_bpb": 1.1639371083082628,
+          "name": "paloma/4chan"
+        },
+        {
+          "bytes": 1237838,
+          "delta_bits": -6845.785968836266,
+          "documents": 256,
+          "gap_bpb": -0.005530437721928286,
+          "model_a_bpb": 0.8358184136400512,
+          "model_b_bpb": 0.8413488513619795,
+          "name": "uncheatable_eval/arxiv_computer_science"
+        }
+      ],
+      "bytes": 23108960,
+      "dataset_groups": [
+        {
+          "bytes": 16006023,
+          "delta_bits": -47253.38936733419,
+          "documents": 3348,
+          "gap_bpb": -0.0029522255070690696,
+          "model_a_bpb": 0.977367713665119,
+          "model_b_bpb": 0.9803199391721881,
+          "name": "paloma"
+        },
+        {
+          "bytes": 7102937,
+          "delta_bits": -39944.10122969605,
+          "documents": 1792,
+          "gap_bpb": -0.005623603479757183,
+          "model_a_bpb": 0.8528940564735656,
+          "model_b_bpb": 0.8585176599533229,
+          "name": "uncheatable_eval"
+        }
+      ],
+      "datasets": [
+        {
+          "bytes": 1067444,
+          "delta_bits": -6485.3729138289955,
+          "documents": 256,
+          "gap_bpb": -0.006075609506286977,
+          "model_a_bpb": 1.157861498801976,
+          "model_b_bpb": 1.1639371083082628,
+          "name": "paloma/4chan"
+        },
+        {
+          "bytes": 744402,
+          "delta_bits": -2073.3094566918626,
+          "documents": 256,
+          "gap_bpb": -0.0027852013518124114,
+          "model_a_bpb": 0.9984435383199378,
+          "model_b_bpb": 1.0012287396717503,
+          "name": "paloma/c4_100_domains"
+        },
+        {
+          "bytes": 523373,
+          "delta_bits": -809.5725530624755,
+          "documents": 256,
+          "gap_bpb": -0.0015468366787405455,
+          "model_a_bpb": 0.9764132719161496,
+          "model_b_bpb": 0.9779601085948901,
+          "name": "paloma/c4_en"
+        },
+        {
+          "bytes": 858825,
+          "delta_bits": -617.7200859594528,
+          "documents": 256,
+          "gap_bpb": -0.000719261882175592,
+          "model_a_bpb": 1.0297456558583944,
+          "model_b_bpb": 1.03046491774057,
+          "name": "paloma/dolma-v1_5"
+        },
+        {
+          "bytes": 898445,
+          "delta_bits": -5917.87943259586,
+          "documents": 256,
+          "gap_bpb": -0.006586802122106372,
+          "model_a_bpb": 0.6539042328970067,
+          "model_b_bpb": 0.6604910350191131,
+          "name": "paloma/dolma_100_programing_languages"
+        },
+        {
+          "bytes": 204005,
+          "delta_bits": 1122.8878367318525,
+          "documents": 256,
+          "gap_bpb": 0.005504217233557278,
+          "model_a_bpb": 1.1354692380134255,
+          "model_b_bpb": 1.1299650207798682,
+          "name": "paloma/dolma_100_subreddits"
+        },
+        {
+          "bytes": 700803,
+          "delta_bits": -1847.307188818191,
+          "documents": 256,
+          "gap_bpb": -0.002635986416750772,
+          "model_a_bpb": 1.0292210556730108,
+          "model_b_bpb": 1.0318570420897617,
+          "name": "paloma/falcon-refinedweb"
+        },
+        {
+          "bytes": 37599,
+          "delta_bits": 2395.3202803267304,
+          "documents": 256,
+          "gap_bpb": 0.06370702094009761,
+          "model_a_bpb": 1.737756037745605,
+          "model_b_bpb": 1.6740490168055073,
+          "name": "paloma/gab"
+        },
+        {
+          "bytes": 5472253,
+          "delta_bits": -13033.237251370008,
+          "documents": 167,
+          "gap_bpb": -0.0023816949346768157,
+          "model_a_bpb": 0.9426660320607515,
+          "model_b_bpb": 0.9450477269954284,
+          "name": "paloma/m2d2_s2orc_unsplit"
+        },
+        {
+          "bytes": 1605632,
+          "delta_bits": -5875.795049963283,
+          "documents": 49,
+          "gap_bpb": -0.00365949049966822,
+          "model_a_bpb": 0.9515524461136428,
+          "model_b_bpb": 0.9552119366133109,
+          "name": "paloma/m2d2_wikipedia_unsplit"
+        },
+        {
+          "bytes": 1000476,
+          "delta_bits": -2175.9760617810502,
+          "documents": 256,
+          "gap_bpb": -0.0021749407899650268,
+          "model_a_bpb": 1.1782543466157338,
+          "model_b_bpb": 1.1804292874056987,
+          "name": "paloma/manosphere_meta_sep"
+        },
+        {
+          "bytes": 974819,
+          "delta_bits": -4647.728649223578,
+          "documents": 256,
+          "gap_bpb": -0.0047677862754250564,
+          "model_a_bpb": 0.9634708806437123,
+          "model_b_bpb": 0.9682386669191374,
+          "name": "paloma/mc4"
+        },
+        {
+          "bytes": 32768,
+          "delta_bits": 127.26609713038928,
+          "documents": 1,
+          "gap_bpb": 0.0038838530618404933,
+          "model_a_bpb": 1.1384025805025437,
+          "model_b_bpb": 1.1345187274407031,
+          "name": "paloma/ptb"
+        },
+        {
+          "bytes": 887837,
+          "delta_bits": -4781.9472540225115,
+          "documents": 256,
+          "gap_bpb": -0.005386064394728437,
+          "model_a_bpb": 0.9546752790619599,
+          "model_b_bpb": 0.9600613434566884,
+          "name": "paloma/redpajama"
+        },
+        {
+          "bytes": 9649,
+          "delta_bits": 2093.282911536461,
+          "documents": 256,
+          "gap_bpb": 0.21694299010638005,
+          "model_a_bpb": 2.960574776904784,
+          "model_b_bpb": 2.7436317867984035,
+          "name": "paloma/twitterAAE_HELM_fixed"
+        },
+        {
+          "bytes": 987693,
+          "delta_bits": -4726.30059574258,
+          "documents": 59,
+          "gap_bpb": -0.004785191953109499,
+          "model_a_bpb": 0.9573587093538388,
+          "model_b_bpb": 0.9621439013069485,
+          "name": "paloma/wikitext_103"
+        },
+        {
+          "bytes": 1223044,
+          "delta_bits": -754.6337854825156,
+          "documents": 256,
+          "gap_bpb": -0.0006170127857072318,
+          "model_a_bpb": 1.1140756549553943,
+          "model_b_bpb": 1.1146926677411015,
+          "name": "uncheatable_eval/ao3_english"
+        },
+        {
+          "bytes": 1237838,
+          "delta_bits": -6845.785968836266,
+          "documents": 256,
+          "gap_bpb": -0.005530437721928286,
+          "model_a_bpb": 0.8358184136400512,
+          "model_b_bpb": 0.8413488513619795,
+          "name": "uncheatable_eval/arxiv_computer_science"
+        },
+        {
+          "bytes": 1282105,
+          "delta_bits": -4800.2748277928995,
+          "documents": 256,
+          "gap_bpb": -0.0037440574896696445,
+          "model_a_bpb": 0.9003981101851118,
+          "model_b_bpb": 0.9041421676747816,
+          "name": "uncheatable_eval/arxiv_physics"
+        },
+        {
+          "bytes": 841249,
+          "delta_bits": -1799.6839573301186,
+          "documents": 256,
+          "gap_bpb": -0.0021392999662764754,
+          "model_a_bpb": 0.9219590181543942,
+          "model_b_bpb": 0.9240983181206707,
+          "name": "uncheatable_eval/bbc_news"
+        },
+        {
+          "bytes": 876685,
+          "delta_bits": -11555.673369543541,
+          "documents": 256,
+          "gap_bpb": -0.013181100816762624,
+          "model_a_bpb": 0.6263959338802806,
+          "model_b_bpb": 0.6395770346970432,
+          "name": "uncheatable_eval/github_cpp"
+        },
+        {
+          "bytes": 1006410,
+          "delta_bits": -13238.543415350297,
+          "documents": 256,
+          "gap_bpb": -0.01315422483416331,
+          "model_a_bpb": 0.5693726442288772,
+          "model_b_bpb": 0.5825268690630405,
+          "name": "uncheatable_eval/github_python"
+        },
+        {
+          "bytes": 635606,
+          "delta_bits": -949.5059053599913,
+          "documents": 256,
+          "gap_bpb": -0.0014938592545696411,
+          "model_a_bpb": 0.9576768448835812,
+          "model_b_bpb": 0.9591707041381508,
+          "name": "uncheatable_eval/wikipedia_english"
+        }
+      ],
+      "documents": 5140,
+      "examples": {
+        "model_a_worse": [
+          {
+            "bytes": 4839,
+            "dataset": "uncheatable_eval/github_cpp",
+            "gap_bpb": 0.40246725550088086,
+            "model_a_bpb": 0.8770143437292804,
+            "model_b_bpb": 0.4745470882283995,
+            "preview": "\u2026plication>\u21b5\u23ce//\u2420#include\u2420\"../src/Calculator.h\"\u21b5\u23ce\u21b5\u23ce//\u2420//\u2420\u0424\u0438\u043a\u0441\u0442\u0443\u0440\u0430\u2420\u0434\u043b\u044f\u2420\u0438\u043d\u0438\u0446\u0438\u0430\u043b\u0438\u0437\u0430\u0446\u0438\u0438\u2420Qt\u21b5\u23ce//\u2420struct\u2420QtFixture\u2420{\u21b5\u23ce//\u2420\u2420\u2420\u2420\u2420Qt\u2026",
+            "row_index": 185,
+            "shard": "github_cpp_20250901to20250914_jsonl_gz",
+            "worst_bucket": "text/non_ascii_word",
+            "worst_gap_bpb": 1.30344788309291,
+            "worst_text": "\u0424\u0438\u043a\u0441\u0442\u0443\u0440\u0430"
+          },
+          {
+            "bytes": 17096,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "gap_bpb": 0.038309236470199216,
+            "model_a_bpb": 1.3905147273956373,
+            "model_b_bpb": 1.3522054909254382,
+            "preview": "\u2026\u2420\u2420\u2420\u2420\u2420\u2420traditional{\"\u0631\u0648\u0627\u06cc\u062a\u06cc\u2420\u0627\u0639\u062f\u0627\u062f\"}\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420vaii{\"\u0648\u0627\u0626\u06cc\u2420\u06c1\u0646\u062f\u0633\u06d2\"}\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420}\u23ce\u2420\u2420\u2420\u2420}\u23ce\u2420\u2420\u2420\u2420Version{\"\u2420|||IP_ADDRESS|||\u2420\"}\u23ce\u2420\u2420\u2420\u2026",
+            "row_index": 31,
+            "shard": "00_text_jsonl_gz",
+            "worst_bucket": "text/non_ascii_word",
+            "worst_gap_bpb": 3.6902206868117644,
+            "worst_text": "\u06c1\u0646\u062f\u0633\u06d2"
+          },
+          {
+            "bytes": 3099,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "gap_bpb": 0.18193426202034915,
+            "model_a_bpb": 0.7675988873300159,
+            "model_b_bpb": 0.5856646253096669,
+            "preview": "\u2026pfn(pt_entry\u2420e);\u21b5\u23ce\u21b5\u23ce//============================================================================\u21b5\u23ce//\u2420\u2420\u2420\u2420INTERFACE\u2420OB\u2026",
+            "row_index": 8,
+            "shard": "02_c_jsonl_gz",
+            "worst_bucket": "text/punctuation",
+            "worst_gap_bpb": 0.3407285441383477,
+            "worst_text": "//=============================\u2026"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "gap_bpb": 0.016051083623996258,
+            "model_a_bpb": 0.5608908720234809,
+            "model_b_bpb": 0.5448397883994845,
+            "preview": "\u2026-\u2420[ajmalafif-suspenders\u24201.18.2](https://github.com/docker-rubygem/ajmalafif-suspenders)\u23ce-\u2420[ajp-rails\u24200.1.0](https://gi\u2026",
+            "row_index": 62,
+            "shard": "01_markdown_jsonl_gz",
+            "worst_bucket": "text/url",
+            "worst_gap_bpb": 2.210003305012369,
+            "worst_text": "https://github.com/docker-rubyg\u2026"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/m2d2_s2orc_unsplit",
+            "gap_bpb": 0.015980403597543474,
+            "model_a_bpb": 1.0285510510562643,
+            "model_b_bpb": 1.0125706474587208,
+            "preview": "\u20263).\u2420One\u2420should\u2420note\u2420that\u2420the\u2420results\u2420on\u2420\u03bb\u2420\u03b3\u2420obtained\u2420by\u2420DELPHI\u2420and\u2420L3\u2420experiments\u2420benefit\u2420information\u2420contained\u2420in\u2420W\u2420p\u2026",
+            "row_index": 0,
+            "shard": "hep-ex_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": 2.9549089089096916,
+            "worst_text": "DELPHI"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/mc4",
+            "gap_bpb": 0.014603633595530604,
+            "model_a_bpb": 1.0018459907782322,
+            "model_b_bpb": 0.9872423571827015,
+            "preview": "\u2026or\u242030%\u2420off.\u2420Buy\u2420DMC\u2420Light\u2420Effects\u2420Embroidery\u2420Floss\u24208.7yd-Rosewood\u2420from\u2420Walmart\u2420Canada.\u2420Free\u2420Store\u2420Pickup.\u2420Buy\u2420Dmc\u2420Embr\u2026",
+            "row_index": 160,
+            "shard": "0_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": 3.0178167542118626,
+            "worst_text": "yd-Rosewood"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/4chan",
+            "gap_bpb": 0.0127858359775151,
+            "model_a_bpb": 1.1344289998252493,
+            "model_b_bpb": 1.1216431638477342,
+            "preview": "\u2026mobemend\u2420widge\u2420promodes\u2420homoseggs,\u2420benis\u2420in\u2420anus\u2420:DDD,\u2420gommunizm,\u2420aids,\u2420and\u2420no\u2420burgers\u2420:DDD\u2420in\u2420diregd\u2420agdion\u2420to\u2420ur\u2420anu\u2026",
+            "row_index": 102,
+            "shard": "1_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": 3.0791007532223205,
+            "worst_text": "gommunizm"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/m2d2_s2orc_unsplit",
+            "gap_bpb": 0.01160811417232992,
+            "model_a_bpb": 0.9050259614823961,
+            "model_b_bpb": 0.8934178473100661,
+            "preview": "\u2026t\u2420be\u2420cut\u2420by\u2420P\u2420.\u2420This\u2420completes\u2420the\u2420proof.\u2420Finally,\u2420the\u2420substars\u2420of\u2420stars\u2420S\u2420e\u2420of\u2420edge-gadgets\u2420T\u2420e\u2420contained\u2420in\u2420G\u2420q\u2420j\u2420ca\u2026",
+            "row_index": 0,
+            "shard": "cs_CC_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": 2.767068655050753,
+            "worst_text": "substars"
+          }
+        ],
+        "model_b_worse": [
+          {
+            "bytes": 32768,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "gap_bpb": -0.08308209598868956,
+            "model_a_bpb": 0.4957878327040084,
+            "model_b_bpb": 0.5788699286926979,
+            "preview": "\u2026;\u2420}\u23ce\u21e5\u23ce}\u23ce\u23cevoid\u2420f21(void)\u2420{\u23ce\u2420\u2420\u2420\u2420\u21e5int8_t\u2420x97\u2420=\u2420INT8_MIN;\u23ce\u21e5volatile\u2420int64_t\u2420x98\u2420=\u2420INT64_MIN;\u23ce\u21e5int32_t\u2420x99\u2420=\u2420INT32_MIN;\u23ce\u21e5st\u2026",
+            "row_index": 14,
+            "shard": "02_c_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": -2.669831001895907,
+            "worst_text": "volatile"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "gap_bpb": -0.04285748464361746,
+            "model_a_bpb": 0.24400513727349243,
+            "model_b_bpb": 0.2868626219171099,
+            "preview": "\u2026y_impl;\u23cetxcb_list_fonts_with_info_sizeof\u2420xcb_list_fonts_with_info_sizeof_impl;\u23cetxcb_list_fonts_with_info\u2420xcb_list_font\u2026",
+            "row_index": 21,
+            "shard": "02_c_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": -2.2432950093420256,
+            "worst_text": "xcb_list_fonts_with_info_sizeof\u2026"
+          },
+          {
+            "bytes": 9701,
+            "dataset": "paloma/redpajama",
+            "gap_bpb": -0.11921034164614,
+            "model_a_bpb": 0.9404498646711215,
+            "model_b_bpb": 1.0596602063172613,
+            "preview": "frette\u2420towels\u2420frette\u2420diamond\u2420bordo\u2420towels\u2420bloomingdales\u2420frette\u2420towels\u2420washing\u2420instructions\u2420symbols.\u23cefrette\u2420towels\u2420fret\u2026",
+            "row_index": 50,
+            "shard": "c4_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": -3.4673462828356407,
+            "worst_text": "frette"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/mc4",
+            "gap_bpb": -0.02693536889931512,
+            "model_a_bpb": 0.6095096272981445,
+            "model_b_bpb": 0.6364449961974596,
+            "preview": "\u2026ions:\u2420[\u2420],\u2420image_urls:\u2420[\u2420'https://images.webfronts.com/cache/frhtxpvaylak.jpg?imgeng=/w_300',\u2420'https://images.webfront\u2026",
+            "row_index": 45,
+            "shard": "0_jsonl_gz",
+            "worst_bucket": "text/url",
+            "worst_gap_bpb": -1.0410720215453395,
+            "worst_text": "https://images.webfronts.com/ca\u2026"
+          },
+          {
+            "bytes": 13783,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "gap_bpb": -0.06013572892533824,
+            "model_a_bpb": 0.6049485710873416,
+            "model_b_bpb": 0.6650843000126799,
+            "preview": "\u20261\u21e5AccessibleExtendedText,\u2420AccessibleRelationSet,\u2420AccessControlContext,\u2420AccessibleState\u21e53\u21e52\u21e53\u21b5142\u21e5AccessController,\u2420Acc\u2026",
+            "row_index": 15,
+            "shard": "00_text_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": -0.7133601842423379,
+            "worst_text": "AccessControlContext"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/mc4",
+            "gap_bpb": -0.024283036945539852,
+            "model_a_bpb": 0.7593390803939781,
+            "model_b_bpb": 0.783622117339518,
+            "preview": "\u2026\u2420with\u2420corresponding\u2420gate\u2420contact\u2420placement\u2420restrictionUS8258552Oct\u24201,\u24202009Sep\u24204,\u24202012Tela\u2420Innovations,\u2420Inc.Semiconduct\u2026",
+            "row_index": 197,
+            "shard": "0_jsonl_gz",
+            "worst_bucket": "text/number",
+            "worst_gap_bpb": -3.9200007576660987,
+            "worst_text": "8258552"
+          },
+          {
+            "bytes": 32441,
+            "dataset": "paloma/redpajama",
+            "gap_bpb": -0.022412862276484178,
+            "model_a_bpb": 0.9114858393211193,
+            "model_b_bpb": 0.9338987015976034,
+            "preview": "\u2026\\cr\u2420}\u2420=\u2420\\hat\u2420V({\\bf\u2420r}),\u21b5\u23ce\\label{Eq:Time_Reversal_Symmetry_of_Interlayer_Potential}\u21b5\u23ce\\end{equation}\u21b5\u23ceor\u21b5\u23ce\\begin{equati\u2026",
+            "row_index": 7,
+            "shard": "arxiv_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": -0.5064485581654636,
+            "worst_text": "Time_Reversal_Symmetry_of_Inter\u2026"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/mc4",
+            "gap_bpb": -0.021226626967423706,
+            "model_a_bpb": 0.6911477212709285,
+            "model_b_bpb": 0.7123743482383522,
+            "preview": "\u2026to-Black\"),url(https://fonts.gstatic.com/s/roboto/v16/3Y_xCyt7TNunMGg0Et2pnoX0hVgzZQUfRDuZrPvH3D8.woff2)\u2420format(\"woff2\u2026",
+            "row_index": 155,
+            "shard": "0_jsonl_gz",
+            "worst_bucket": "text/url",
+            "worst_gap_bpb": -0.6535606726179649,
+            "worst_text": "https://fonts.gstatic.com/s/rob\u2026"
+          }
+        ]
+      },
+      "label": "GPT-OSS tokenizer, 200k vocab",
+      "losses": 4,
+      "model": "gpt-oss-200k",
+      "overall_gap_bpb": -0.00377331955211442,
+      "paloma_gap_bpb": -0.0029522255070690696,
+      "pattern_buckets": [
+        {
+          "bytes": 110850,
+          "delta_bits": 5390.770239403761,
+          "documents": 33576,
+          "gap_bpb": 0.048631215511084895,
+          "model_a_bpb": 1.4631923802156523,
+          "model_b_bpb": 1.4145611647045673,
+          "name": "text/non_ascii"
+        },
+        {
+          "bytes": 243363,
+          "delta_bits": -1259.2604313092643,
+          "documents": 36486,
+          "gap_bpb": -0.005174412015422494,
+          "model_a_bpb": 1.3070892011589221,
+          "model_b_bpb": 1.3122636131743446,
+          "name": "text/non_ascii_word"
+        },
+        {
+          "bytes": 581666,
+          "delta_bits": -4493.901817841176,
+          "documents": 173710,
+          "gap_bpb": -0.007725914558941345,
+          "model_a_bpb": 1.4222102809777748,
+          "model_b_bpb": 1.429936195536716,
+          "name": "text/number"
+        },
+        {
+          "bytes": 993004,
+          "delta_bits": 1577.9543361004273,
+          "documents": 799744,
+          "gap_bpb": 0.0015890714801757367,
+          "model_a_bpb": 1.3367453283492066,
+          "model_b_bpb": 1.3351562568690307,
+          "name": "text/punctuation"
+        },
+        {
+          "bytes": 97492,
+          "delta_bits": 193.45677759251072,
+          "documents": 1923,
+          "gap_bpb": 0.0019843348950940665,
+          "model_a_bpb": 1.036841791658742,
+          "model_b_bpb": 1.034857456763648,
+          "name": "text/url"
+        },
+        {
+          "bytes": 17035730,
+          "delta_bits": -47891.99337143696,
+          "documents": 3430328,
+          "gap_bpb": -0.0028112674579508458,
+          "model_a_bpb": 0.8829695978430901,
+          "model_b_bpb": 0.8857808653010409,
+          "name": "text/word"
+        },
+        {
+          "bytes": 377098,
+          "delta_bits": -4914.123552322376,
+          "documents": 47781,
+          "gap_bpb": -0.013031423004954617,
+          "model_a_bpb": 0.3420611595182875,
+          "model_b_bpb": 0.3550925825232422,
+          "name": "whitespace/mixed"
+        },
+        {
+          "bytes": 35659,
+          "delta_bits": -3700.1328617084564,
+          "documents": 13755,
+          "gap_bpb": -0.10376434733751526,
+          "model_a_bpb": 1.5804899884401655,
+          "model_b_bpb": 1.6842543357776805,
+          "name": "whitespace/multi_newline"
+        },
+        {
+          "bytes": 30687,
+          "delta_bits": 687.4375278793393,
+          "documents": 5586,
+          "gap_bpb": 0.022401587899740585,
+          "model_a_bpb": 0.8359733952316394,
+          "model_b_bpb": 0.8135718073318988,
+          "name": "whitespace/multi_space"
+        },
+        {
+          "bytes": 81421,
+          "delta_bits": 922.2424680371757,
+          "documents": 81421,
+          "gap_bpb": 0.011326837892400925,
+          "model_a_bpb": 1.5625772592625182,
+          "model_b_bpb": 1.5512504213701175,
+          "name": "whitespace/newline"
+        },
+        {
+          "bytes": 3424589,
+          "delta_bits": -33054.98929080628,
+          "documents": 3424589,
+          "gap_bpb": -0.00965225003374311,
+          "model_a_bpb": 1.029137760998922,
+          "model_b_bpb": 1.038790011032665,
+          "name": "whitespace/single_space"
+        },
+        {
+          "bytes": 97401,
+          "delta_bits": -654.9506203932315,
+          "documents": 20609,
+          "gap_bpb": -0.006724269980731527,
+          "model_a_bpb": 0.627994724892523,
+          "model_b_bpb": 0.6347189948732544,
+          "name": "whitespace/tab_or_cr"
+        }
+      ],
+      "ties": 0,
+      "top_literals": {
+        "model_a_worse": [
+          {
+            "bucket": "text/word",
+            "bytes": 51012,
+            "delta_bits": 2938.292790064584,
+            "documents": 5668,
+            "example_dataset": "paloma/4chan",
+            "example_doc_preview": "\u2026han\u2420\"\u2420the\u2420problem\u2420will\u2420solve\u2420itself\u2420no\u2420matter\u2420what.\"\u23ce\u23ce\u23ceAnonymous\u242008/27/17(Sun)14:46:28\u2420no.139250388:\u23ceYOU\u2420NIGGERS\u2420NEED\u2420\u2026",
+            "gap_bpb": 0.05760003117040273,
+            "model_a_bpb": 0.11459478876314805,
+            "model_a_token_boundaries": "|Anonymous|",
+            "model_b_bpb": 0.056994757592745304,
+            "model_b_token_boundaries": "|Anonymous|",
+            "name": "Anonymous"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 14405,
+            "delta_bits": 1689.256146916165,
+            "documents": 14405,
+            "example_dataset": "paloma/dolma_100_subreddits",
+            "example_doc_preview": "\u2420I\u2420developed\u2420it\u2420about\u242018\u2420years\u2420ago\u2420and\u2420it\u2420was\u2420so\u2420bizarre.\u2420It\u2420started\u2420with\u2420stone\u2420fruit\u2420(peaches,\u2420plums,\u2420cherries),\u2420then\u2026",
+            "gap_bpb": 0.11726873633572822,
+            "model_a_bpb": 1.8475688950077958,
+            "model_a_token_boundaries": "|\u2026I|",
+            "model_b_bpb": 1.7303001586720674,
+            "model_b_token_boundaries": "|\u2026I|",
+            "name": "I"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 6594,
+            "delta_bits": 1567.0845010671378,
+            "documents": 3297,
+            "example_dataset": "uncheatable_eval/github_cpp",
+            "example_doc_preview": "\u2420//\u2420Why\u2420the\u2420angle\u2420brackets?\u2420Grader\u2420reasons.\u23ce\u2420//\u2420Don't\u2420change\u2420this\u2420or\u2420you\u2420will\u2420be\u2420sad\u2420:(\u23ce#include\u2420<prqueue.h>\u23ce\u23ce#include\u2026",
+            "gap_bpb": 0.23765309388339972,
+            "model_a_bpb": 0.7990750117468378,
+            "model_a_token_boundaries": "|\u2026//|",
+            "model_b_bpb": 0.5614219178634381,
+            "model_b_token_boundaries": "|\u2026//|",
+            "name": "//"
+          },
+          {
+            "bucket": "text/non_ascii",
+            "bytes": 2124,
+            "delta_bits": 1246.7131659459274,
+            "documents": 531,
+            "example_dataset": "uncheatable_eval/ao3_english",
+            "example_doc_preview": "\u2026u\u2420okay?\u201d\u201cMmh-hmm.\u201d\u2420A\u2420gentle\u2420hum\u2420and\u2420nod\u2420into\u2420your\u2420shoulder.\u201cDid\u2420you\u2420get\u2420all\u2420those\u2420dirty\u2420thoughts\u2420out\u2420of\u2420your\u2420system?\u201d\u201c\u2026",
+            "gap_bpb": 0.5869647673945044,
+            "model_a_bpb": 2.560328685183771,
+            "model_a_token_boundaries": "|.\u201c|",
+            "model_b_bpb": 1.973363917789267,
+            "model_b_token_boundaries": "|.\u201c|",
+            "name": ".\u201c"
+          },
+          {
+            "bucket": "whitespace/tab_or_cr",
+            "bytes": 2920,
+            "delta_bits": 1235.4069736123583,
+            "documents": 730,
+            "example_dataset": "paloma/manosphere_meta_sep",
+            "example_doc_preview": "\u2026k\u2420to\u2420expand...\u2420Beta\u2420bux.\u2420\u23ce\u23ce\u23cewhogivesafucc:\u23ce\u2420Captvic\u2420said:\u2420\u21e5\u21e5\u21e5Beta\u2420bux.\u2420\u21e5\u21e5\u2420Click\u2420to\u2420expand...\u2420...in\u2420college?\u2420i\u2420mean\u2420pos\u2026",
+            "gap_bpb": 0.4230845800042323,
+            "model_a_bpb": 1.781904386835602,
+            "model_a_token_boundaries": "|\u2420\u21e5\u21e5|\u21e5\u2026|",
+            "model_b_bpb": 1.3588198068313697,
+            "model_b_token_boundaries": "|\u2420\u21e5\u21e5|\u21e5\u2026|",
+            "name": "\u2420\u21e5\u21e5\u21e5"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 4130,
+            "delta_bits": 1162.8095867564018,
+            "documents": 826,
+            "example_dataset": "paloma/manosphere_meta_sep",
+            "example_doc_preview": "\u2026y\u2420walk\u2420hand\u2420in\u2420hand\u2420with\u2420their\u2420friends\u2420and\u2420kiss\u2420them?\u2420\u21e5\u21e5\u2420Click\u2420to\u2420expand...\u2420Beta\u2420bux.\u2420\u23ce\u23ce\u23cewhogivesafucc:\u23ce\u2420Captvic\u2420said:\u2026",
+            "gap_bpb": 0.2815519580523975,
+            "model_a_bpb": 0.8190731993242795,
+            "model_a_token_boundaries": "|\u2026Click|",
+            "model_b_bpb": 0.5375212412718819,
+            "model_b_token_boundaries": "|\u2026Click|",
+            "name": "Click"
+          },
+          {
+            "bucket": "text/non_ascii",
+            "bytes": 9549,
+            "delta_bits": 1110.4189621667915,
+            "documents": 3183,
+            "example_dataset": "paloma/falcon-refinedweb",
+            "example_doc_preview": "\u201c\u23ce\"If\u2420you\u2420want\u2420to\u2420be\u2420happy,\u2420be.\"\u2420-\u2420Leo\u2420Tolstoy\u23ce\"Forever\u2420is\u2420composed\u2420of\u2420nows.\"\u2420-\u2420Emily\u2420Dickinson\u23ce\u201cWe\u2420all\u2420wear\u2420masks,\u2420an\u2026",
+            "gap_bpb": 0.11628641346390109,
+            "model_a_bpb": 1.192419424311355,
+            "model_a_token_boundaries": "|\u201c\u2026|",
+            "model_b_bpb": 1.076133010847454,
+            "model_b_token_boundaries": "|\u201c|",
+            "name": "\u201c"
+          },
+          {
+            "bucket": "text/non_ascii",
+            "bytes": 2088,
+            "delta_bits": 1078.750722826285,
+            "documents": 1044,
+            "example_dataset": "uncheatable_eval/arxiv_computer_science",
+            "example_doc_preview": "\u00a7\u2420Abstract\u2420While\u2420existing\u2420critical\u2420care\u2420EHR\u2420datasets\u2420such\u2420as\u2420MIMIC\u2420and\u2420eICU\u2420have\u2420enabled\u2420significant\u2420advances\u2420in\u2420clini\u2026",
+            "gap_bpb": 0.5166430664876844,
+            "model_a_bpb": 5.8268761346590505,
+            "model_a_token_boundaries": "|\u00a7|",
+            "model_b_bpb": 5.310233068171366,
+            "model_b_token_boundaries": "|\u00a7|",
+            "name": "\u00a7"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 264,
+            "delta_bits": 1066.292765785414,
+            "documents": 132,
+            "example_dataset": "paloma/dolma_100_programing_languages",
+            "example_doc_preview": "<?php\u23ce\u23cenamespace\u2420LRVM\\Domain\\Category;\u23ce\u23ceinterface\u2420CategoryRepository\u2420{\u23ce\u23ce\u2420\u2420\u2420\u2420/**\u23ce\u2420\u2420\u2420\u2420\u2420*\u2420Get\u2420all\u2420primary\u2420categories\u23ce\u2420\u2420\u2420\u2420\u2026",
+            "gap_bpb": 4.038987749187174,
+            "model_a_bpb": 4.458787237332102,
+            "model_a_token_boundaries": "|<?|",
+            "model_b_bpb": 0.4197994881449264,
+            "model_b_token_boundaries": "|<?|",
+            "name": "<?"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 14161,
+            "delta_bits": 966.0692553383924,
+            "documents": 2023,
+            "example_dataset": "uncheatable_eval/github_cpp",
+            "example_doc_preview": "#include\u2420\"{{cookiecutter.class_name_file}}.h\"\u23ce#include\u2420<godot_cpp/core/class_db.hpp>\u23ce#include\u2420<godot_cpp/godot.hpp>\u23ce#i\u2026",
+            "gap_bpb": 0.0682204120710679,
+            "model_a_bpb": 0.32339816321350995,
+            "model_a_token_boundaries": "|\u2026include|",
+            "model_b_bpb": 0.25517775114244207,
+            "model_b_token_boundaries": "|\u2026include|",
+            "name": "include"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 7679,
+            "delta_bits": 962.7478951901359,
+            "documents": 7679,
+            "example_dataset": "paloma/dolma_100_programing_languages",
+            "example_doc_preview": "\u2026ere\u5b50\u53e5\u5b57\u5178\u3002key:where\u5b50\u53e5\u9075\u5faa\u7ed1\u5b9a\u8bed\u6cd5\uff0cvalue\uff1a\u7ed1\u5b9a\u503c\u6570\u7ec4\u3002\u6bd4\u5982\u201cwhere\u2420name\u2420=\u2420'John'\u2420AND\u2420age\u2420=\u2420'17'\u201d\u2420->\u2420@{@\"WHERE\u2420name\u2420=\u2420?\u2420AND\u2420age\u2420=\u2420?\":@[@\"Jo\u2026",
+            "gap_bpb": 0.12537412360856048,
+            "model_a_bpb": 1.638791471805886,
+            "model_a_token_boundaries": "|'|",
+            "model_b_bpb": 1.5134173481973254,
+            "model_b_token_boundaries": "|'|",
+            "name": "'"
+          },
+          {
+            "bucket": "whitespace/newline",
+            "bytes": 81421,
+            "delta_bits": 922.2424680371757,
+            "documents": 81421,
+            "example_dataset": "paloma/falcon-refinedweb",
+            "example_doc_preview": ";\u23ceVIEWS:\u24208\u2420PAGES:\u24204\u2420CATEGORY:\u2420Childrens\u2420Literature\u2420POSTED\u2420ON:\u242011/27/2009\u23ceTRIAD\u2420INTERNSHIP\u2420INFORMATION\u2420SHEET\u2420for\u2420underg\u2026",
+            "gap_bpb": 0.011326837892400925,
+            "model_a_bpb": 1.5625772592625182,
+            "model_a_token_boundaries": "|\u2026\u23ce|",
+            "model_b_bpb": 1.5512504213701175,
+            "model_b_token_boundaries": "|\u2026\u23ce|",
+            "name": "\u23ce"
+          }
+        ],
+        "model_b_worse": [
+          {
+            "bucket": "whitespace/single_space",
+            "bytes": 3424589,
+            "delta_bits": -33054.98929080628,
+            "documents": 3424589,
+            "example_dataset": "paloma/dolma_100_programing_languages",
+            "example_doc_preview": "\u2026{\"\u062c\u0631\u0645\u0646\"}\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420de_AT{\"\u0622\u0633\u0679\u0631\u06cc\u0627\u0626\u06cc\u2420\u062c\u0631\u0645\u0646\"}\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420de_CH{\"\u0633\u0648\u0626\u0633\u2420\u06c1\u0627\u0626\u06cc\u2420\u062c\u0631\u0645\u0646\"}\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420dje{\"\u0632\u0631\u0645\u0627\"}\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420dsb{\"\u0630\u06cc\u0644\u06cc\u2420\u0633\u0631\u0628\u06cc\u0627\u0626\u06cc\"\u2026",
+            "gap_bpb": -0.00965225003374311,
+            "model_a_bpb": 1.029137760998922,
+            "model_a_token_boundaries": "|\u2420\u2026|",
+            "model_b_bpb": 1.038790011032665,
+            "model_b_token_boundaries": "|\u2420|",
+            "name": "\u2420"
+          },
+          {
+            "bucket": "whitespace/multi_newline",
+            "bytes": 23724,
+            "delta_bits": -3954.7208595424636,
+            "documents": 7908,
+            "example_dataset": "paloma/4chan",
+            "example_doc_preview": "\u2026\u2420instead\u2420of\u2420looking\u2420it\u2420up\u23ceCan't\u2420make\u2420this\u2420stuff\u2420up\u2420goys!!!\u23ce\u23ce\u23ceAnonymous\u242007/24/17(Mon)11:52:51\u2420no.134771933:\u23ce>>134766535\u2026",
+            "gap_bpb": -0.16669705191124867,
+            "model_a_bpb": 1.8944795444781803,
+            "model_a_token_boundaries": "|\u2026\u23ce\u23ce|\u23ce|",
+            "model_b_bpb": 2.0611765963894286,
+            "model_b_token_boundaries": "|\u23ce\u23ce\u23ce|",
+            "name": "\u23ce\u23ce\u23ce"
+          },
+          {
+            "bucket": "whitespace/mixed",
+            "bytes": 4515,
+            "delta_bits": -1750.1619954386,
+            "documents": 903,
+            "example_dataset": "paloma/wikitext_103",
+            "example_doc_preview": "\u2026rformance\u2420Music\u2420Video\u2420.\u2420\u23ce\u2420\u23ce\u2420=\u2420=\u2420Writing\u2420and\u2420recording\u2420=\u2420=\u2420\u23ce\u2420\u23ce\u2420The\u2420music\u2420for\u2420\"\u2420Where\u2420the\u2420Streets\u2420Have\u2420No\u2420Name\u2420\"\u2420origina\u2026",
+            "gap_bpb": -0.3876327786132004,
+            "model_a_bpb": 1.4459253582569578,
+            "model_a_token_boundaries": "|\u2420\u23ce\u2420\u23ce|\u2420\u2026|",
+            "model_b_bpb": 1.8335581368701583,
+            "model_b_token_boundaries": "|\u2420\u23ce\u2420\u23ce|\u2420\u2026|",
+            "name": "\u2420\u23ce\u2420\u23ce\u2420"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 178473,
+            "delta_bits": -1674.7724659624434,
+            "documents": 178473,
+            "example_dataset": "paloma/falcon-refinedweb",
+            "example_doc_preview": ".\u2420Walking\u2420distance\u2420to\u2420downtown\u2420Blaine,\u2420Starbucks,\u2420the\u2420marina,\u2420and\u2420the\u2420waterfront.\u2420Convenient\u2420freeway\u2420access\u2420is\u2420nearby..",
+            "gap_bpb": -0.009383898214085288,
+            "model_a_bpb": 1.6516735262483142,
+            "model_a_token_boundaries": "|.|",
+            "model_b_bpb": 1.661057424462399,
+            "model_b_token_boundaries": "|.|",
+            "name": "."
+          },
+          {
+            "bucket": "whitespace/mixed",
+            "bytes": 6724,
+            "delta_bits": -1483.6099570566591,
+            "documents": 1681,
+            "example_dataset": "paloma/manosphere_meta_sep",
+            "example_doc_preview": "\u2026\u2420wrote.\u2420\u21e5\u21e5\u21e5\u21e5\u21e5\u21e5\u21e5\u21e5\u2420\u21e5\u21e5\u21e5\u21e5\u21e5\u21e5\u21e5\u21e5\u21e5Last\u2420edited:\u2420Monday\u2420at\u242012:10\u2420AM\u2420\u23ce\u23ce\u23ceordinaryotaku:\u23ce\u2420Hikikomori\u2420said:\u2420\u21e5\u21e5\u21e5Nah,\u2420it's\u2420about\u2420wakin\u2026",
+            "gap_bpb": -0.2206439555408476,
+            "model_a_bpb": 2.281893838783562,
+            "model_a_token_boundaries": "|\u2420\u23ce\u23ce\u23ce|",
+            "model_b_bpb": 2.502537794324409,
+            "model_b_token_boundaries": "|\u2420\u23ce\u23ce\u23ce|",
+            "name": "\u2420\u23ce\u23ce\u23ce"
+          },
+          {
+            "bucket": "whitespace/tab_or_cr",
+            "bytes": 288,
+            "delta_bits": -1136.1153299732455,
+            "documents": 96,
+            "example_dataset": "paloma/manosphere_meta_sep",
+            "example_doc_preview": "\u2026mited.\u2420By\u2420that\u2420sole\u2420fact\u2420it\u2420makes\u2420them\u2420extremely\u2420valuable.\u2420\u21b5\u2420If\u2420you\u2420want\u2420equality\u2420in\u2420relationships,\u2420you\u2420need\u2420at\u2420least\u2420\u2026",
+            "gap_bpb": -3.944844895740436,
+            "model_a_bpb": 3.9430855242402245,
+            "model_a_token_boundaries": "|\u2420|\u21b5|\u2420\u2026|",
+            "model_b_bpb": 7.887930419980659,
+            "model_b_token_boundaries": "|\u2420\u21b5|\u2420\u2026|",
+            "name": "\u2420\u21b5\u2420"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 28274,
+            "delta_bits": -1116.4924239811603,
+            "documents": 28274,
+            "example_dataset": "uncheatable_eval/arxiv_computer_science",
+            "example_doc_preview": ":\u2420Complex\u2420Analytics\u2420on\u2420Private\u2420Data\u2420with\u2420Strong\u2420Security\u2420Guarantees\u23ce\u00a7\u2420Abstract\u2420We\u2420present\u2420,\u2420a\u2420system\u2420that\u2420enables\u2420coll\u2026",
+            "gap_bpb": -0.039488308126942075,
+            "model_a_bpb": 1.3903992376108352,
+            "model_a_token_boundaries": "|:|",
+            "model_b_bpb": 1.4298875457377773,
+            "model_b_token_boundaries": "|:|",
+            "name": ":"
+          },
+          {
+            "bucket": "text/non_ascii_word",
+            "bytes": 1348,
+            "delta_bits": -1001.0283911097775,
+            "documents": 674,
+            "example_dataset": "uncheatable_eval/arxiv_physics",
+            "example_doc_preview": "\u2026m\u2420perturbative\u2420QCD\u2420(pQCD)\u2420at\u2420asymptotically\u2420high\u2420densities\u2420\u03c1\u2273\u242040\u2420\u03c1_\u2420sat\u2420and\u2420chiral\u2420effective\u2420field\u2420theory\u2420(EFT)\u2420calcul\u2026",
+            "gap_bpb": -0.7426026640280249,
+            "model_a_bpb": 0.8871426657410408,
+            "model_a_token_boundaries": "|\u03c1|",
+            "model_b_bpb": 1.6297453297690656,
+            "model_b_token_boundaries": "|\u2026\u03c1|\u03c1|",
+            "name": "\u03c1"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 6772,
+            "delta_bits": -983.788246551599,
+            "documents": 6772,
+            "example_dataset": "paloma/c4_en",
+            "example_doc_preview": ">\u2420>\u2420with\u2420slip=1\u2420--\u2420return\u2420TC=1\u2420responses\u2420to\u2420all\u2420queries\u2420over\u2420the\u2420limit.\u23cegoal,\u2420and\u2420slip=1\u2420achieves\u2420that.\u23celatency\u2420hit\u2420is\u2026",
+            "gap_bpb": -0.14527292477135248,
+            "model_a_bpb": 1.4687806184664254,
+            "model_a_token_boundaries": "|>|",
+            "model_b_bpb": 1.614053543237778,
+            "model_b_token_boundaries": "|>|",
+            "name": ">"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 4647,
+            "delta_bits": -956.8451986378797,
+            "documents": 1549,
+            "example_dataset": "paloma/wikitext_103",
+            "example_doc_preview": "\u2026e\u242096\u2420kilometres\u2420(\u242060\u2420mi\u2420)\u2420west\u2420of\u2420Papa\u2420Stour\u2420.\u2420The\u2420'\u2420tide\u2420@-@\u2420lumps\u2420'\u2420are\u2420increased\u2420swells\u2420of\u2420unusual\u2420size\u2420due\u2420to\u2420the\u2420\u2026",
+            "gap_bpb": -0.20590600358034855,
+            "model_a_bpb": 2.0494400382639193,
+            "model_a_token_boundaries": "|\u2026@|-|@|",
+            "model_b_bpb": 2.2553460418442683,
+            "model_b_token_boundaries": "|\u2026@|-|@|",
+            "name": "@-@"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 1656,
+            "delta_bits": -843.9457787346757,
+            "documents": 276,
+            "example_dataset": "paloma/redpajama",
+            "example_doc_preview": "frette\u2420towels\u2420frette\u2420diamond\u2420bordo\u2420towels\u2420bloomingdales\u2420frette\u2420towels\u2420washing\u2420instructions\u2420symbols.\u23cefrette\u2420towels\u2420fret\u2026",
+            "gap_bpb": -0.5096290934388139,
+            "model_a_bpb": 0.1750608468211144,
+            "model_a_token_boundaries": "|\u2026f|rette|",
+            "model_b_bpb": 0.6846899402599282,
+            "model_b_token_boundaries": "|\u2026fret|te|",
+            "name": "frette"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 51702,
+            "delta_bits": -836.5075010001053,
+            "documents": 17234,
+            "example_dataset": "paloma/wikitext_103",
+            "example_doc_preview": "\u2026y\u2420through\u2420their\u2420website\u2420.\u2420The\u2420June\u242012\u2420episode\u2420of\u2420Impact\u2420!\u2420was\u2420dedicated\u2420to\u2420Sinex\u2420,\u2420with\u2420a\u2420banner\u2420at\u2420the\u2420beginning\u2420of\u2420t\u2026",
+            "gap_bpb": -0.016179403137211428,
+            "model_a_bpb": 0.6436187601380156,
+            "model_a_token_boundaries": "|\u2026was|",
+            "model_b_bpb": 0.659798163275227,
+            "model_b_token_boundaries": "|\u2026was|",
+            "name": "was"
+          }
+        ]
+      },
+      "top_segments": {
+        "model_a_worse": [
+          {
+            "bucket": "text/url",
+            "bytes": 55,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": 121.5501817756803,
+            "doc_preview": "\u2026-\u2420[ajmalafif-suspenders\u24201.18.2](https://github.com/docker-rubygem/ajmalafif-suspenders)\u23ce-\u2420[ajp-rails\u24200.1.0](https://gi\u2026",
+            "gap_bpb": 2.210003305012369,
+            "text": "https://github.com/docker-rubyg\u2026"
+          },
+          {
+            "bucket": "text/non_ascii_word",
+            "bytes": 47,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": 119.48584581223895,
+            "doc_preview": "\u2026\"WHERE\u2420name\u2420=\u2420?\u2420AND\u2420age\u2420=\u2420?\":@[@\"John\",@\"17\"]}\u3002\u8981\u4fdd\u8bc1where\u5b57\u5178\u6709\u4e14\u4ec5\u6709\u4e00\u7ec4key-value\u23ce@param\u2420block\u2420\u56de\u8c03\u23ce@return\u2420\u67e5\u8be2\u7ed3\u679c\u23ce*/\u23ce-\u2420(NSMutableA\u2026",
+            "gap_bpb": 2.5422520385582756,
+            "text": "\u8981\u4fdd\u8bc1where\u5b57\u5178\u6709\u4e14\u4ec5\u6709\u4e00\u7ec4key-value"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 475,
+            "dataset": "paloma/mc4",
+            "delta_bits": 86.98227226741861,
+            "doc_preview": "\u2026ewiip.jpg?imgeng=/w_300','https://images.webfronts.com/cache/frjtxgjtcvku.jpg?imgeng=/w_300','https://images.webfronts\u2026",
+            "gap_bpb": 0.18312057319456548,
+            "text": "https://images.webfronts.com/ca\u2026"
+          },
+          {
+            "bucket": "text/non_ascii_word",
+            "bytes": 24,
+            "dataset": "uncheatable_eval/wikipedia_english",
+            "delta_bits": 77.99596068582736,
+            "doc_preview": "\u2026ed\u2420to\u2420the\u2420site\u2420of\u2420the\u2420ruined\u2420church\u2420south\u2420of\u2420Jujurusi\u2420(\u10ef\u10e3\u10ef\u10e3\u10e0\u10e3\u10e1\u10d8)\u2420village\u2420and\u2420near\u2420Zardenisi\u2420(\u10d6\u10d0\u10e0\u10d3\u10d4\u10dc\u10d8\u10e1\u10d8)\u2420village\u2420as\u2420\"Te\u2026",
+            "gap_bpb": 3.2498316952428064,
+            "text": "\u10ef\u10e3\u10ef\u10e3\u10e0\u10e3\u10e1\u10d8"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 24,
+            "dataset": "paloma/4chan",
+            "delta_bits": 68.2544612455336,
+            "doc_preview": "\u2026https://www.reddit.com/r/IAmA/comme\u23cents/ai2det/were_the_krassenstein_br\u23ceothers_we_uncovered_a/\u23ce\u23ce\u23ceAnonymous\u242001/22/19(Tu\u2026",
+            "gap_bpb": 2.8439358852305667,
+            "text": "were_the_krassenstein_br"
+          },
+          {
+            "bucket": "text/number",
+            "bytes": 23,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": 66.18840958313707,
+            "doc_preview": "\u20262730\u23ce1627409729162:14933189:\u4e24\u4e2a\u4eba\u4e00\u8d77\u73a9\u5f97\u597d\u6e29\u99a8(\u0e51\u203e\u2420\ua1f4\u2420\u203e\u0e51)\u23ce1627409743746:110767787:\u8054\u52a8\u9e1f\u516d\u773c\u73e0\u5b50\u4e86\u545c\u545c\u545c\u23ceTIME2:15ONLINE2730\u23ce1627409772024:1\u2026",
+            "gap_bpb": 2.877756938397264,
+            "text": "1627409743746:110767787"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 13,
+            "dataset": "paloma/manosphere_meta_sep",
+            "delta_bits": 65.54264178775009,
+            "doc_preview": "\u2026nd...\u2420how\u2420does\u2420that\u2420count\u2420as\u2420a\u2420conversation\u2420\u23ce\u23ce\u23ceKV3:\u23ce\u2420whogivesafucc\u2420said:\u2420\u21e5\u21e5\u21e5how\u2420does\u2420that\u2420count\u2420as\u2420a\u2420conversation\u2420\u21e5\u21e5\u2420C\u2026",
+            "gap_bpb": 5.041741675980775,
+            "text": "whogivesafucc"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 58,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": 63.73045675466368,
+            "doc_preview": "\u2026[adamcooke-key-installer\u24201.1](https://github.com/docker-rubygem/adamcooke-key-installer)\u23ce-\u2420[adamcooke-radar\u24201.0.0](htt\u2026",
+            "gap_bpb": 1.098800978528684,
+            "text": "https://github.com/docker-rubyg\u2026"
+          },
+          {
+            "bucket": "text/number",
+            "bytes": 23,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": 61.58279175720397,
+            "doc_preview": "\u202627478421326:224664194:\u5c0f\u592b\u2420\u54d2\u54a9\u23ceTIME21:20ONLINE3715\u23ce1627478450992:224664194:\uff1f\uff1f\uff1f\u23ceTIME21:20ONLINE3715\u23ceTIME21:20ONLINE3693\u23ce16\u2026",
+            "gap_bpb": 2.6775126850958246,
+            "text": "1627478450992:224664194"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 208,
+            "dataset": "paloma/gab",
+            "delta_bits": 53.71751245296582,
+            "doc_preview": "\u2026nn-state-trustee-bows-out-of-election-after-disparaging-sandusky-victims/?utm_source=feedburner&utm_medium=feed&utm_ca\u2026",
+            "gap_bpb": 0.25825727140848953,
+            "text": "http://www.breitbart.com/sports\u2026"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 21,
+            "dataset": "paloma/4chan",
+            "delta_bits": 53.026876218458774,
+            "doc_preview": "\u2026r/IAmA/comme\u23cents/ai2det/were_the_krassenstein_br\u23ceothers_we_uncovered_a/\u23ce\u23ce\u23ceAnonymous\u242001/22/19(Tue)16:12:00\u2420no.200689082\u2026",
+            "gap_bpb": 2.525089343736132,
+            "text": "others_we_uncovered_a"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 19,
+            "dataset": "paloma/mc4",
+            "delta_bits": 52.543593274706154,
+            "doc_preview": "\u2026ENGINE\\EraserUtilRebootDrv.sys\u23ce08:50:10.0637\u24204588\u21e5EraserUtilRebootDrv\u2420-\u2420ok\u23ce08:50:10.0684\u24204588\u21e5ErrDev\u2420(34a3c54752046e79\u2026",
+            "gap_bpb": 2.7654522776161135,
+            "text": "EraserUtilRebootDrv"
+          }
+        ],
+        "model_b_worse": [
+          {
+            "bucket": "text/url",
+            "bytes": 49,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": -94.83834164272939,
+            "doc_preview": "\u2026em/akane)\u23ce-\u2420[akane-bigquery\u24200.1.0](https://github.com/docker-rubygem/akane-bigquery)\u23ce-\u2420[akapen\u24200.0.1](https://github.c\u2026",
+            "gap_bpb": -1.935476360055702,
+            "text": "https://github.com/docker-rubyg\u2026"
+          },
+          {
+            "bucket": "text/non_ascii_word",
+            "bytes": 47,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": -93.3009568238837,
+            "doc_preview": "\u2026\"WHERE\u2420name\u2420=\u2420?\u2420AND\u2420age\u2420=\u2420?\":@[@\"John\",@\"17\"]}\u3002\u8981\u4fdd\u8bc1where\u5b57\u5178\u6709\u4e14\u4ec5\u6709\u4e00\u7ec4key-value\u23ce@param\u2420block\u2420\u56de\u8c03\u23ce@return\u2420\u67e5\u8be2\u7ed3\u679c\u23ce*/\u23ce-\u2420(NSMutableA\u2026",
+            "gap_bpb": -1.9851267409336957,
+            "text": "\u8981\u4fdd\u8bc1where\u5b57\u5178\u6709\u4e14\u4ec5\u6709\u4e00\u7ec4key-value"
+          },
+          {
+            "bucket": "text/non_ascii_word",
+            "bytes": 57,
+            "dataset": "uncheatable_eval/github_cpp",
+            "delta_bits": -84.69750373258304,
+            "doc_preview": "\u2026\u2420\"\\nRandom\u2420\uc544\uc774\ud15c\uc744\u2420\uad6c\ub9e4\ud569\ub2c8\ub2e4!\\n\";\u21b5\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420std::cout\u2420<<\u2420\"\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\\n\";\u21b5\u23ce\u21b5\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420switch\u2420(random)\u21b5\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420{\u21b5\u23ce\u2420\u2420\u2420\u2420\u2420\u2026",
+            "gap_bpb": -1.485921118115492,
+            "text": "\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 36,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": -80.75862033631293,
+            "doc_preview": "\u2026y_impl;\u23cetxcb_list_fonts_with_info_sizeof\u2420xcb_list_fonts_with_info_sizeof_impl;\u23cetxcb_list_fonts_with_info\u2420xcb_list_font\u2026",
+            "gap_bpb": -2.2432950093420256,
+            "text": "xcb_list_fonts_with_info_sizeof\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 67,
+            "dataset": "paloma/mc4",
+            "delta_bits": -69.75182544353774,
+            "doc_preview": "\u2026ions:\u2420[\u2420],\u2420image_urls:\u2420[\u2420'https://images.webfronts.com/cache/frhtxpvaylak.jpg?imgeng=/w_300',\u2420'https://images.webfront\u2026",
+            "gap_bpb": -1.0410720215453395,
+            "text": "https://images.webfronts.com/ca\u2026"
+          },
+          {
+            "bucket": "text/non_ascii_word",
+            "bytes": 144,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": -68.14375807697422,
+            "doc_preview": "\u2026\uff0c\u4e5f\u9020\u6210\u4e86\u4ea7\u4e1a\u7ed3\u6784\u7684\u4e25\u91cd\u5931\u8861\u3002\u5b9e\u884c\u4ea7\u4e1a\u7ed3\u6784\u975e\u5747\u8861\u534f\u8c03\u53d1\u5c55\u653f\u7b56\uff0c\u6b63\u662f\u21b5\u23ce\u7531\u524d\u4e00\u65f6\u671f\u6211\u56fd\u4ea7\u4e1a\u7ed3\u6784\u53d8\u52a8\u7684\u8d85\u524d\u6027\u6240\u9057\u7559\u4e0b\u7684\u7ed3\u6784\u7f3a\u9677\u548c\u73b0\u9636\u6bb5\u6211\u56fd\u4ea7\u4e1a\u7ed3\u6784\u52a8\u6001\u53d8\u5316\u7684\u5ba2\u89c2\u5b9e\u9645\u51b3\u5b9a\u7684\u3002\u4ea7\u4e1a\u7ed3\u6784\u975e\u5747\u8861\u534f\u8c03\u653f\u7b56\u7684\u4e3b\u21b5\u23ce\u8981\u5185\u5bb9\u662f\uff1a\u4ee5\u652f\u914d\u4ea7\u4e1a\u7684\u53d1\u5c55\u6765\u5e26\u52a8\u4ece\u5c5e\u4ea7\u2026",
+            "gap_bpb": -0.4732205422012099,
+            "text": "\u7531\u524d\u4e00\u65f6\u671f\u6211\u56fd\u4ea7\u4e1a\u7ed3\u6784\u53d8\u52a8\u7684\u8d85\u524d\u6027\u6240\u9057\u7559\u4e0b\u7684\u7ed3\u6784\u7f3a\u9677\u548c\u73b0\u9636\u6bb5\u6211\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 89,
+            "dataset": "paloma/mc4",
+            "delta_bits": -58.166899862998875,
+            "doc_preview": "\u2026to-Black\"),url(https://fonts.gstatic.com/s/roboto/v16/3Y_xCyt7TNunMGg0Et2pnoX0hVgzZQUfRDuZrPvH3D8.woff2)\u2420format(\"woff2\u2026",
+            "gap_bpb": -0.6535606726179649,
+            "text": "https://fonts.gstatic.com/s/rob\u2026"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 13,
+            "dataset": "paloma/manosphere_meta_sep",
+            "delta_bits": -57.58256902867451,
+            "doc_preview": "\u2026ds\u2420and\u2420kiss\u2420them?\u2420\u21e5\u21e5\u2420Click\u2420to\u2420expand...\u2420Beta\u2420bux.\u2420\u23ce\u23ce\u23cewhogivesafucc:\u23ce\u2420Captvic\u2420said:\u2420\u21e5\u21e5\u21e5Beta\u2420bux.\u2420\u21e5\u21e5\u2420Click\u2420to\u2420expand...\u2420\u2026",
+            "gap_bpb": -4.429428386821116,
+            "text": "whogivesafucc"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 15,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": -53.05504697666223,
+            "doc_preview": "\u2026https://github.com/docker-rubygem/adammck-pants)\u23ce-\u2420[adammck-rubygsm\u24200.41](https://github.com/docker-rubygem/adammck-ru\u2026",
+            "gap_bpb": -3.537003131777482,
+            "text": "adammck-rubygsm"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 10,
+            "dataset": "paloma/redpajama",
+            "delta_bits": -50.57210248928921,
+            "doc_preview": "\u2026re2_e}\u23ce\u21e5\\hspace{0.05cm}\u23ce\u21e5\\includegraphics[scale=0.25]{FiguresEps/Figure2_f}\u23ce\u21e5\\hspace{0.05cm}\u23ce\u21e5\\includegraphics[scale=0\u2026",
+            "gap_bpb": -5.057210248928921,
+            "text": "FiguresEps"
+          },
+          {
+            "bucket": "text/number",
+            "bytes": 21,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": -50.44557072543957,
+            "doc_preview": "\u2026833923:1875520:\u554a\u2420\u5e94\u8be5\u5728\u5927\u4e71\u6597\u7684\u65f6\u5019\u5f00\u7684\u23ceTIME21:10ONLINE3861\u23ce1627477881583:7614937:\u90a3\u5565\u65f6\u5019\u8dd1\u56e2\u634f\u23ceTIME21:11ONLINE3861\u23ce1627477888214:18755\u2026",
+            "gap_bpb": -2.4021700345447417,
+            "text": "1627477881583:7614937"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 347,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": -48.46973055611488,
+            "doc_preview": "\u2026-volta-a-ccj,35d85c70ab1c6b35d1d71581dcde39ec46backtw.html](https://www.terra.com.br/noticias/brasil/politica/senado-d\u2026",
+            "gap_bpb": -0.13968222062280947,
+            "text": "https://www.terra.com.br/notici\u2026"
+          }
+        ]
+      },
+      "uncheatable_gap_bpb": -0.005623603479757183,
+      "wins": 19
+    },
+    {
+      "baseline": "llama3-128k",
+      "biggest_losses": [
+        {
+          "bytes": 1006410,
+          "delta_bits": 10030.839522370961,
+          "documents": 256,
+          "gap_bpb": 0.009966951364126907,
+          "model_a_bpb": 0.5924938204271675,
+          "model_b_bpb": 0.5825268690630405,
+          "name": "uncheatable_eval/github_python"
+        },
+        {
+          "bytes": 876685,
+          "delta_bits": 7397.275211969415,
+          "documents": 256,
+          "gap_bpb": 0.008437780060077924,
+          "model_a_bpb": 0.6480148147571212,
+          "model_b_bpb": 0.6395770346970432,
+          "name": "uncheatable_eval/github_cpp"
+        },
+        {
+          "bytes": 987693,
+          "delta_bits": 2473.6643692223684,
+          "documents": 59,
+          "gap_bpb": 0.0025044870918619127,
+          "model_a_bpb": 0.9646483883988104,
+          "model_b_bpb": 0.9621439013069485,
+          "name": "paloma/wikitext_103"
+        },
+        {
+          "bytes": 5472253,
+          "delta_bits": 10558.129471854589,
+          "documents": 167,
+          "gap_bpb": 0.0019293935188768846,
+          "model_a_bpb": 0.9469771205143053,
+          "model_b_bpb": 0.9450477269954284,
+          "name": "paloma/m2d2_s2orc_unsplit"
+        },
+        {
+          "bytes": 1605632,
+          "delta_bits": 2617.876975268221,
+          "documents": 49,
+          "gap_bpb": 0.0016304339819262577,
+          "model_a_bpb": 0.9568423705952371,
+          "model_b_bpb": 0.9552119366133109,
+          "name": "paloma/m2d2_wikipedia_unsplit"
+        }
+      ],
+      "biggest_wins": [
+        {
+          "bytes": 9649,
+          "delta_bits": -713.2513583440652,
+          "documents": 256,
+          "gap_bpb": -0.07391971793388592,
+          "model_a_bpb": 2.6697120688645177,
+          "model_b_bpb": 2.7436317867984035,
+          "name": "paloma/twitterAAE_HELM_fixed"
+        },
+        {
+          "bytes": 37599,
+          "delta_bits": -596.1799150132305,
+          "documents": 256,
+          "gap_bpb": -0.015856270512865513,
+          "model_a_bpb": 1.6581927462926418,
+          "model_b_bpb": 1.6740490168055073,
+          "name": "paloma/gab"
+        },
+        {
+          "bytes": 1067444,
+          "delta_bits": -13598.924988154704,
+          "documents": 256,
+          "gap_bpb": -0.012739708114106879,
+          "model_a_bpb": 1.1511974001941558,
+          "model_b_bpb": 1.1639371083082628,
+          "name": "paloma/4chan"
+        },
+        {
+          "bytes": 1000476,
+          "delta_bits": -3079.947371849408,
+          "documents": 256,
+          "gap_bpb": -0.0030784820144105483,
+          "model_a_bpb": 1.1773508053912882,
+          "model_b_bpb": 1.1804292874056987,
+          "name": "paloma/manosphere_meta_sep"
+        },
+        {
+          "bytes": 204005,
+          "delta_bits": -468.54960704548705,
+          "documents": 256,
+          "gap_bpb": -0.0022967555062154703,
+          "model_a_bpb": 1.1276682652736527,
+          "model_b_bpb": 1.1299650207798682,
+          "name": "paloma/dolma_100_subreddits"
+        }
+      ],
+      "bytes": 23108960,
+      "dataset_groups": [
+        {
+          "bytes": 16006023,
+          "delta_bits": -6333.697950739506,
+          "documents": 3348,
+          "gap_bpb": -0.0003957071629060827,
+          "model_a_bpb": 0.9799242320092819,
+          "model_b_bpb": 0.9803199391721881,
+          "name": "paloma"
+        },
+        {
+          "bytes": 7102937,
+          "delta_bits": 13936.62701024325,
+          "documents": 1792,
+          "gap_bpb": 0.001962093569215558,
+          "model_a_bpb": 0.8604797535225385,
+          "model_b_bpb": 0.8585176599533229,
+          "name": "uncheatable_eval"
+        }
+      ],
+      "datasets": [
+        {
+          "bytes": 1067444,
+          "delta_bits": -13598.924988154704,
+          "documents": 256,
+          "gap_bpb": -0.012739708114106879,
+          "model_a_bpb": 1.1511974001941558,
+          "model_b_bpb": 1.1639371083082628,
+          "name": "paloma/4chan"
+        },
+        {
+          "bytes": 744402,
+          "delta_bits": -921.3945938067247,
+          "documents": 256,
+          "gap_bpb": -0.0012377648015544354,
+          "model_a_bpb": 0.9999909748701958,
+          "model_b_bpb": 1.0012287396717503,
+          "name": "paloma/c4_100_domains"
+        },
+        {
+          "bytes": 523373,
+          "delta_bits": -1091.2924656044236,
+          "documents": 256,
+          "gap_bpb": -0.0020851141835830727,
+          "model_a_bpb": 0.9758749944113071,
+          "model_b_bpb": 0.9779601085948901,
+          "name": "paloma/c4_en"
+        },
+        {
+          "bytes": 858825,
+          "delta_bits": -1037.6657882254922,
+          "documents": 256,
+          "gap_bpb": -0.001208238917387701,
+          "model_a_bpb": 1.0292566788231823,
+          "model_b_bpb": 1.03046491774057,
+          "name": "paloma/dolma-v1_5"
+        },
+        {
+          "bytes": 898445,
+          "delta_bits": 97.81376122012406,
+          "documents": 256,
+          "gap_bpb": 0.00010887006018189657,
+          "model_a_bpb": 0.660599905079295,
+          "model_b_bpb": 0.6604910350191131,
+          "name": "paloma/dolma_100_programing_languages"
+        },
+        {
+          "bytes": 204005,
+          "delta_bits": -468.54960704548705,
+          "documents": 256,
+          "gap_bpb": -0.0022967555062154703,
+          "model_a_bpb": 1.1276682652736527,
+          "model_b_bpb": 1.1299650207798682,
+          "name": "paloma/dolma_100_subreddits"
+        },
+        {
+          "bytes": 700803,
+          "delta_bits": -620.2475591995993,
+          "documents": 256,
+          "gap_bpb": -0.0008850526598767404,
+          "model_a_bpb": 1.030971989429885,
+          "model_b_bpb": 1.0318570420897617,
+          "name": "paloma/falcon-refinedweb"
+        },
+        {
+          "bytes": 37599,
+          "delta_bits": -596.1799150132305,
+          "documents": 256,
+          "gap_bpb": -0.015856270512865513,
+          "model_a_bpb": 1.6581927462926418,
+          "model_b_bpb": 1.6740490168055073,
+          "name": "paloma/gab"
+        },
+        {
+          "bytes": 5472253,
+          "delta_bits": 10558.129471854589,
+          "documents": 167,
+          "gap_bpb": 0.0019293935188768846,
+          "model_a_bpb": 0.9469771205143053,
+          "model_b_bpb": 0.9450477269954284,
+          "name": "paloma/m2d2_s2orc_unsplit"
+        },
+        {
+          "bytes": 1605632,
+          "delta_bits": 2617.876975268221,
+          "documents": 49,
+          "gap_bpb": 0.0016304339819262577,
+          "model_a_bpb": 0.9568423705952371,
+          "model_b_bpb": 0.9552119366133109,
+          "name": "paloma/m2d2_wikipedia_unsplit"
+        },
+        {
+          "bytes": 1000476,
+          "delta_bits": -3079.947371849408,
+          "documents": 256,
+          "gap_bpb": -0.0030784820144105483,
+          "model_a_bpb": 1.1773508053912882,
+          "model_b_bpb": 1.1804292874056987,
+          "name": "paloma/manosphere_meta_sep"
+        },
+        {
+          "bytes": 974819,
+          "delta_bits": 378.9355449735689,
+          "documents": 256,
+          "gap_bpb": 0.00038872400412134857,
+          "model_a_bpb": 0.9686273909232588,
+          "model_b_bpb": 0.9682386669191374,
+          "name": "paloma/mc4"
+        },
+        {
+          "bytes": 32768,
+          "delta_bits": 7.558064006377206,
+          "documents": 1,
+          "gap_bpb": 0.0002306538087883669,
+          "model_a_bpb": 1.1347493812494915,
+          "model_b_bpb": 1.1345187274407031,
+          "name": "paloma/ptb"
+        },
+        {
+          "bytes": 887837,
+          "delta_bits": -340.2224900410845,
+          "documents": 256,
+          "gap_bpb": -0.00038320377506353585,
+          "model_a_bpb": 0.9596781396816249,
+          "model_b_bpb": 0.9600613434566884,
+          "name": "paloma/redpajama"
+        },
+        {
+          "bytes": 9649,
+          "delta_bits": -713.2513583440652,
+          "documents": 256,
+          "gap_bpb": -0.07391971793388592,
+          "model_a_bpb": 2.6697120688645177,
+          "model_b_bpb": 2.7436317867984035,
+          "name": "paloma/twitterAAE_HELM_fixed"
+        },
+        {
+          "bytes": 987693,
+          "delta_bits": 2473.6643692223684,
+          "documents": 59,
+          "gap_bpb": 0.0025044870918619127,
+          "model_a_bpb": 0.9646483883988104,
+          "model_b_bpb": 0.9621439013069485,
+          "name": "paloma/wikitext_103"
+        },
+        {
+          "bytes": 1223044,
+          "delta_bits": 438.9586979333174,
+          "documents": 256,
+          "gap_bpb": 0.00035890670976131475,
+          "model_a_bpb": 1.115051574450863,
+          "model_b_bpb": 1.1146926677411015,
+          "name": "uncheatable_eval/ao3_english"
+        },
+        {
+          "bytes": 1237838,
+          "delta_bits": -942.5557127728938,
+          "documents": 256,
+          "gap_bpb": -0.0007614532053248437,
+          "model_a_bpb": 0.8405873981566546,
+          "model_b_bpb": 0.8413488513619795,
+          "name": "uncheatable_eval/arxiv_computer_science"
+        },
+        {
+          "bytes": 1282105,
+          "delta_bits": -935.0177566708192,
+          "documents": 256,
+          "gap_bpb": -0.0007292832932332525,
+          "model_a_bpb": 0.9034128843815482,
+          "model_b_bpb": 0.9041421676747816,
+          "name": "uncheatable_eval/arxiv_physics"
+        },
+        {
+          "bytes": 841249,
+          "delta_bits": -868.7822443838697,
+          "documents": 256,
+          "gap_bpb": -0.0010327290069692442,
+          "model_a_bpb": 0.9230655891137014,
+          "model_b_bpb": 0.9240983181206707,
+          "name": "uncheatable_eval/bbc_news"
+        },
+        {
+          "bytes": 876685,
+          "delta_bits": 7397.275211969415,
+          "documents": 256,
+          "gap_bpb": 0.008437780060077924,
+          "model_a_bpb": 0.6480148147571212,
+          "model_b_bpb": 0.6395770346970432,
+          "name": "uncheatable_eval/github_cpp"
+        },
+        {
+          "bytes": 1006410,
+          "delta_bits": 10030.839522370961,
+          "documents": 256,
+          "gap_bpb": 0.009966951364126907,
+          "model_a_bpb": 0.5924938204271675,
+          "model_b_bpb": 0.5825268690630405,
+          "name": "uncheatable_eval/github_python"
+        },
+        {
+          "bytes": 635606,
+          "delta_bits": -1184.0907082023573,
+          "documents": 256,
+          "gap_bpb": -0.0018629319235538325,
+          "model_a_bpb": 0.957307772214597,
+          "model_b_bpb": 0.9591707041381508,
+          "name": "uncheatable_eval/wikipedia_english"
+        }
+      ],
+      "documents": 5140,
+      "examples": {
+        "model_a_worse": [
+          {
+            "bytes": 32768,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "gap_bpb": 0.07827921449768721,
+            "model_a_bpb": 0.6571491431903852,
+            "model_b_bpb": 0.5788699286926979,
+            "preview": "\u202687\u2420=\u2420(((x417/x418)==x419)-x420);\u23ce\u23ce\u2420\u2420\u2420\u2420if\u2420(t87\u2420!=\u2420-9223372036854775807LL)\u2420{\u2420NG();\u2420}\u2420else\u2420{\u2420;\u2420}\u23ce\u21e5\u23ce}\u23ce\u23cevoid\u2420f88(void)\u2420{\u23ce\u2420\u2420\u2026",
+            "row_index": 14,
+            "shard": "02_c_jsonl_gz",
+            "worst_bucket": "text/number",
+            "worst_gap_bpb": 1.69470690367771,
+            "worst_text": "9223372036854775807"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/mc4",
+            "gap_bpb": 0.06700749302814275,
+            "model_a_bpb": 1.0542498502108444,
+            "model_b_bpb": 0.9872423571827015,
+            "preview": "\u2026d\u2420and\u2420disclosed\u2420accordance.\u24204.99\u2420Save\u242020\u2420%\u2420with\u2420code\u242020MADEBYYOU\u242011\u2420colors\u242036/Pkg\u2420from\u2420Walmart\u2420Canada\u2420third\u2420party\u2420for\u2420\u2026",
+            "row_index": 160,
+            "shard": "0_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": 6.027768870352457,
+            "worst_text": "MADEBYYOU"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/mc4",
+            "gap_bpb": 0.030893080820453445,
+            "model_a_bpb": 0.5372947105519261,
+            "model_b_bpb": 0.5064016297314727,
+            "preview": "\u2026.,\u2420cf.\u2420\u2420Patent\u2420Documents\u24201-4).\u23ce[Non-patent\u2420Document\u24201]\u2420ECOC-IOOC\u2420Proceedings\u2420Vol.\u24203,\u2420Paper\u2420We4.\u2420\u2420P.\u242014-15,\u24202003\u23ceThe\u2420in\u2026",
+            "row_index": 113,
+            "shard": "0_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": 4.5547268919644335,
+            "worst_text": "ECOC-IOOC"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/mc4",
+            "gap_bpb": 0.025676253626722347,
+            "model_a_bpb": 1.446261005960198,
+            "model_b_bpb": 1.4205847523334756,
+            "preview": "\u2026dows\\System32\\drivers\\mshidkmdf.sys\u23ce08:50:22.0697\u24204588\u21e5mshidkmdf\u2420-\u2420ok\u23ce08:50:22.0744\u24204588\u21e5msisadrv\u2420(d916874bbd4f8b07bfb\u2026",
+            "row_index": 122,
+            "shard": "0_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": 7.059565063810175,
+            "worst_text": "mshidkmdf"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/4chan",
+            "gap_bpb": 0.022718810143667778,
+            "model_a_bpb": 1.144361973991402,
+            "model_b_bpb": 1.1216431638477342,
+            "preview": "\u20264:25:45\u2420no.139248144:\u23ce>>139247715\u23ce>It\u2420is\u2420a\u2420group\u2420of\u2420che\u2420Larpers\u2420who\u2420are\u2420attacking\u2420a\u2420strawman\u23ce>Antifa\u2420is\u2420full\u2420of\u2420Comple\u2026",
+            "row_index": 102,
+            "shard": "1_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": 4.457382220102078,
+            "worst_text": "Larpers"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/m2d2_s2orc_unsplit",
+            "gap_bpb": 0.02183430225349812,
+            "model_a_bpb": 1.1279463069086484,
+            "model_b_bpb": 1.1061120046551502,
+            "preview": "\u2026e\u2420after\u2420killing\u2420the\u2420Devil's\u2420son\u2420in\u2420the\u2420story.25\u23ceIn\u2420the\u2420specif\u0133ic\u2420context\u2420of\u2420this\u2420story,\u2420the\u2420views\u2420of\u2420al-Tirmidh\u012b\u2420regar\u2026",
+            "row_index": 0,
+            "shard": "Philosophy_jsonl_gz",
+            "worst_bucket": "text/non_ascii_word",
+            "worst_gap_bpb": 1.9769080531875205,
+            "worst_text": "specif\u0133ic"
+          },
+          {
+            "bytes": 32441,
+            "dataset": "paloma/redpajama",
+            "gap_bpb": 0.01909564931694933,
+            "model_a_bpb": 0.9529943509145526,
+            "model_b_bpb": 0.9338987015976034,
+            "preview": "\u2026e\u2420Brillouin\u2420zone\u2420shown\u2420in\u2420Fig.\\\u2420\\ref{Fig:Lattice_Structure_and_Brillouin_Zone}\u2420(b),\u2420where\u2420the\u2420Fermi\u2420level\u2420is\u2420located.\\\u2026",
+            "row_index": 7,
+            "shard": "arxiv_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": 2.089427773601661,
+            "worst_text": "Lattice_Structure_and_Brillouin\u2026"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/m2d2_s2orc_unsplit",
+            "gap_bpb": 0.018177997754820728,
+            "model_a_bpb": 1.138170322559142,
+            "model_b_bpb": 1.119992324804321,
+            "preview": "\u2026\ufe00\u2420F\u2420such\u2420that\u2420F(x)\u2420=\u0302\ufe00\u2420F(1\u2420+\u2420\u03b4\u24202\u2420)\u2420with\u2420|\u03b4\u24202\u2420|\u2420\u2264\u24202\u2420\u2212p\u2420.\u2420Hence\u0302\ufe00\u2420G/\u0302\ufe00\u2420F\u2420=\u2420(G(x)/F(x))(1+\u03b4\u24203\u2420)\u2420where\u2420|\u03b4\u24203\u2420|\u2420=\u2420|\u03b4\u24201\u2420+\u03b4\u24202\u2420\u2026",
+            "row_index": 0,
+            "shard": "cs_SC_jsonl_gz",
+            "worst_bucket": "text/non_ascii_word",
+            "worst_gap_bpb": 4.327100132161959,
+            "worst_text": "Hence\u0302\ufe00"
+          }
+        ],
+        "model_b_worse": [
+          {
+            "bytes": 17096,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "gap_bpb": -0.0962827972351013,
+            "model_a_bpb": 1.255922693690337,
+            "model_b_bpb": 1.3522054909254382,
+            "preview": "\u2026guages%short{\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420az{\"\u0627\u0632\u06cc\u0631\u06cc\"}\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420en_GB{\"\u0628\u0631\u0637\u0627\u0646\u0648\u06cc\u2420\u0627\u0646\u06af\u0644\u0634\"}\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420en_US{\"\u0627\u0645\u0631\u06cc\u06a9\u06cc\u2420\u0627\u0646\u06af\u0644\u0634\"}\u23ce\u2420\u2420\u2420\u2420}\u23ce\u2420\u2420\u2420\u2420Scripts{\u23ce\u2420\u2420\u2420\u2420\u2026",
+            "row_index": 31,
+            "shard": "00_text_jsonl_gz",
+            "worst_bucket": "text/non_ascii_word",
+            "worst_gap_bpb": -2.0320038344085636,
+            "worst_text": "\u0627\u0646\u06af\u0644\u0634"
+          },
+          {
+            "bytes": 29024,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "gap_bpb": -0.030001070275551843,
+            "model_a_bpb": 0.5979852964512606,
+            "model_b_bpb": 0.6279863667268125,
+            "preview": "\u2026201~\u21b5\u23ce~03003~^~315~^~S2113~\u21b5\u23ce~03003~^~341~^~S2113~\u21b5\u23ce~03003~^~406~^~S2113~\u21b5\u23ce~03003~^~629~^~S2113~\u21b5\u23ce~03003~^~653~^~S2113\u2026",
+            "row_index": 26,
+            "shard": "00_text_jsonl_gz",
+            "worst_bucket": "text/punctuation",
+            "worst_gap_bpb": -9.848783972675902,
+            "worst_text": "~^~"
+          },
+          {
+            "bytes": 15562,
+            "dataset": "paloma/mc4",
+            "gap_bpb": -0.05024140908084975,
+            "model_a_bpb": 0.9531198183364916,
+            "model_b_bpb": 1.0033612274173416,
+            "preview": "\u2026aining\u2420ink\u2420levels\u2420accurately\u2420reported\u2420for\u2420compatible\u2420printers-same\u2420as\u2420oem\u2420capability\u2420one-year\u2420limited\u2420warranty.\u2420High\u2420c\u2026",
+            "row_index": 47,
+            "shard": "1_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": -2.7536619430067213,
+            "worst_text": "printers-same"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/mc4",
+            "gap_bpb": -0.01704064701282328,
+            "model_a_bpb": 0.695333701225529,
+            "model_b_bpb": 0.7123743482383522,
+            "preview": "\u2026cal(\"Roboto-Thin\"),url(https://fonts.gstatic.com/s/roboto/v20/KFOkCnqEu92Fr1MmgVxMIzIFKw.woff2)\u2420format(\"woff2\");unicod\u2026",
+            "row_index": 155,
+            "shard": "0_jsonl_gz",
+            "worst_bucket": "text/url",
+            "worst_gap_bpb": -2.601859819469097,
+            "worst_text": "https://fonts.gstatic.com/s/rob\u2026"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/4chan",
+            "gap_bpb": -0.016853479438278758,
+            "model_a_bpb": 1.1528156300344388,
+            "model_b_bpb": 1.1696691094727176,
+            "preview": "\u20260\u23ce>https://www.themoscowtimes.com/201\u23ce9/03/05/russia-will-be-one-third-mu\u23ceslim-in-15-years-chief-mufti-predic\u23cets-a6470\u2026",
+            "row_index": 110,
+            "shard": "0_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": -1.8633160675732887,
+            "worst_text": "russia-will-be-one-third-mu"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/4chan",
+            "gap_bpb": -0.01683981312373347,
+            "model_a_bpb": 1.0740796183437245,
+            "model_b_bpb": 1.090919431467458,
+            "preview": "\u2026\u2420I\u2420do\u2420believe\u2420it.\u23ce\u23ce\u23ceAnonymous\u242009/21/18(Fri)19:19:53\u2420no.186502848:\u23ce>>186502540\u23ce>kill\u2420other\u2420people\u2420for\u2420minor\u2420disagreemen\u2026",
+            "row_index": 66,
+            "shard": "0_jsonl_gz",
+            "worst_bucket": "text/number",
+            "worst_gap_bpb": -4.304891376659665,
+            "worst_text": "186502848"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/4chan",
+            "gap_bpb": -0.014407259052809561,
+            "model_a_bpb": 1.092827186528675,
+            "model_b_bpb": 1.1072344455814844,
+            "preview": "\u2026ut\u2420through\u2420steel?\u23ce\u23ce\u23ceAnonymous\u242001/04/19(Fri)17:17:20\u2420no.198734593:\u23ce>>198729141\u23ce>BA\u2420in\u2420Econ\u23ce>knows\u2420more\u2420about\u2420economics\u23ce\u2026",
+            "row_index": 0,
+            "shard": "0_jsonl_gz",
+            "worst_bucket": "text/number",
+            "worst_gap_bpb": -3.9172901264813476,
+            "worst_text": "198734593"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/4chan",
+            "gap_bpb": -0.013178774975357252,
+            "model_a_bpb": 1.2190690282447747,
+            "model_b_bpb": 1.232247803220132,
+            "preview": "\u2026e\u2420away\u2420so\u2420easily?\u23ce\u23ce\u23ceAnonymous\u242008/23/18(Thu)07:30:36\u2420no.183205688:\u23ce>>183197255\u23ceMake\u2420Love\u2420Not\u2420Wars\u23ce\u23ce\u23ceAnonymous\u242008/23/18(\u2026",
+            "row_index": 24,
+            "shard": "0_jsonl_gz",
+            "worst_bucket": "text/number",
+            "worst_gap_bpb": -3.9677348785308744,
+            "worst_text": "183205688"
+          }
+        ]
+      },
+      "label": "Qwen3 tokenizer, 152k vocab",
+      "losses": 9,
+      "model": "qwen3-152k",
+      "overall_gap_bpb": 0.0003290035146326267,
+      "paloma_gap_bpb": -0.0003957071629060827,
+      "pattern_buckets": [
+        {
+          "bytes": 110850,
+          "delta_bits": 2879.9791352567267,
+          "documents": 33576,
+          "gap_bpb": 0.025980867255360637,
+          "model_a_bpb": 1.440542031959928,
+          "model_b_bpb": 1.4145611647045673,
+          "name": "text/non_ascii"
+        },
+        {
+          "bytes": 243363,
+          "delta_bits": 3184.9946398021216,
+          "documents": 36486,
+          "gap_bpb": 0.013087423477694315,
+          "model_a_bpb": 1.3253510366520391,
+          "model_b_bpb": 1.3122636131743446,
+          "name": "text/non_ascii_word"
+        },
+        {
+          "bytes": 581666,
+          "delta_bits": -41903.32065442909,
+          "documents": 173710,
+          "gap_bpb": -0.07204017538317366,
+          "model_a_bpb": 1.3578960201535424,
+          "model_b_bpb": 1.429936195536716,
+          "name": "text/number"
+        },
+        {
+          "bytes": 993004,
+          "delta_bits": 20126.156213205308,
+          "documents": 799744,
+          "gap_bpb": 0.020267950796980988,
+          "model_a_bpb": 1.3554242076660117,
+          "model_b_bpb": 1.3351562568690307,
+          "name": "text/punctuation"
+        },
+        {
+          "bytes": 97492,
+          "delta_bits": -328.3247904433896,
+          "documents": 1923,
+          "gap_bpb": -0.0033677100730664013,
+          "model_a_bpb": 1.0314897466905815,
+          "model_b_bpb": 1.034857456763648,
+          "name": "text/url"
+        },
+        {
+          "bytes": 17035730,
+          "delta_bits": 16169.57899637498,
+          "documents": 3430328,
+          "gap_bpb": 0.0009491568014035782,
+          "model_a_bpb": 0.8867300221024446,
+          "model_b_bpb": 0.8857808653010409,
+          "name": "text/word"
+        },
+        {
+          "bytes": 377098,
+          "delta_bits": -408.2209527590085,
+          "documents": 47781,
+          "gap_bpb": -0.0010825327972012807,
+          "model_a_bpb": 0.35401004972604083,
+          "model_b_bpb": 0.3550925825232422,
+          "name": "whitespace/mixed"
+        },
+        {
+          "bytes": 35659,
+          "delta_bits": -5408.739781955867,
+          "documents": 13755,
+          "gap_bpb": -0.15167951378209898,
+          "model_a_bpb": 1.5325748219955817,
+          "model_b_bpb": 1.6842543357776805,
+          "name": "whitespace/multi_newline"
+        },
+        {
+          "bytes": 30687,
+          "delta_bits": 48.99745164743205,
+          "documents": 5586,
+          "gap_bpb": 0.001596684317379739,
+          "model_a_bpb": 0.8151684916492786,
+          "model_b_bpb": 0.8135718073318988,
+          "name": "whitespace/multi_space"
+        },
+        {
+          "bytes": 81421,
+          "delta_bits": 1285.7193029512348,
+          "documents": 81421,
+          "gap_bpb": 0.01579100358569945,
+          "model_a_bpb": 1.5670414249558169,
+          "model_b_bpb": 1.5512504213701175,
+          "name": "whitespace/newline"
+        },
+        {
+          "bytes": 3424589,
+          "delta_bits": 6395.264302498429,
+          "documents": 3424589,
+          "gap_bpb": 0.0018674545478299524,
+          "model_a_bpb": 1.040657465580495,
+          "model_b_bpb": 1.038790011032665,
+          "name": "whitespace/single_space"
+        },
+        {
+          "bytes": 97401,
+          "delta_bits": 5560.845196965616,
+          "documents": 20609,
+          "gap_bpb": 0.05709228033557783,
+          "model_a_bpb": 0.6918112752088322,
+          "model_b_bpb": 0.6347189948732544,
+          "name": "whitespace/tab_or_cr"
+        }
+      ],
+      "ties": 0,
+      "top_literals": {
+        "model_a_worse": [
+          {
+            "bucket": "whitespace/single_space",
+            "bytes": 3424589,
+            "delta_bits": 6395.264302498429,
+            "documents": 3424589,
+            "example_dataset": "paloma/redpajama",
+            "example_doc_preview": "\u2026gure[experiment]\u23ce\u2420\u2420\u2420\u2420{\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\\includegraphics[trim\u2420=\u242020mm\u24200mm\u242020mm\u24200mm,\u2420clip=true,\u2420width=0.45\\textwidth]{Figure_fork\u2026",
+            "gap_bpb": 0.0018674545478299524,
+            "model_a_bpb": 1.040657465580495,
+            "model_a_token_boundaries": "|\u2420|",
+            "model_b_bpb": 1.038790011032665,
+            "model_b_token_boundaries": "|\u2420|",
+            "name": "\u2420"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 183488,
+            "delta_bits": 2797.8711909000126,
+            "documents": 183488,
+            "example_dataset": "paloma/mc4",
+            "example_doc_preview": "\u2026320,\u2420400],\u2420[[320,\u2420100],\u2420[320,\u242050],\u2420[300,\u242050],\u2420[234,\u242060],\u2420[1,\u24201]]).addSize([0,\u24200],\u2420[[300,\u242050],\u2420[234,\u242060],\u2420[1,\u24201]]).buil\u2026",
+            "gap_bpb": 0.01524825160718964,
+            "model_a_bpb": 1.8333541791975478,
+            "model_a_token_boundaries": "|,|",
+            "model_b_bpb": 1.8181059275903582,
+            "model_b_token_boundaries": "|,|",
+            "name": ","
+          },
+          {
+            "bucket": "whitespace/tab_or_cr",
+            "bytes": 2920,
+            "delta_bits": 2378.4623583966704,
+            "documents": 730,
+            "example_dataset": "paloma/manosphere_meta_sep",
+            "example_doc_preview": "\u2026l,\u2420just\u2420fucking\u2420lol.\u2420\u23ce\u23ce\u23ceUnfortunatelyINCEL98:\u23ce\u2420Yoyo\u2420said:\u2420\u21e5\u21e5\u21e5You\u2420missed\u2420the\u2420opportunities\u2420in\u2420highschool\u2420or\u2420middle\u2420scho\u2026",
+            "gap_bpb": 0.8145419035605036,
+            "model_a_bpb": 2.1733617103918736,
+            "model_a_token_boundaries": "|\u2420\u21e5\u21e5|\u21e5|",
+            "model_b_bpb": 1.3588198068313697,
+            "model_b_token_boundaries": "|\u2420\u21e5\u21e5|\u21e5|",
+            "name": "\u2420\u21e5\u21e5\u21e5"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 10108,
+            "delta_bits": 1797.1203457561605,
+            "documents": 10108,
+            "example_dataset": "paloma/m2d2_s2orc_unsplit",
+            "example_doc_preview": "\u2026\u2420unitary\u2420vertex\u2420operator\u2420algebra,\u2420by\u2420Corollary\u24202.8\u2420in\u2420[DLin]\u2420we\u2420only\u2420need\u2420to\u2420prove\u2420that\u2420\u03c6(\u03c9\u2420\u2032\u2420)\u2420=\u2420\u03c9\u2420\u2032\u2420,\u2420where\u2420\u03c9\u2420\u2032\u2420deno\u2026",
+            "gap_bpb": 0.17779188224734474,
+            "model_a_bpb": 1.210492119478649,
+            "model_a_token_boundaries": "|]|",
+            "model_b_bpb": 1.0327002372313043,
+            "model_b_token_boundaries": "|]|",
+            "name": "]"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 10452,
+            "delta_bits": 1542.5373522776472,
+            "documents": 5226,
+            "example_dataset": "paloma/4chan",
+            "example_doc_preview": "\u2026ster.\u23ce3/?\u23ce\u23ce\u23ceAnonymous\u242001/01/17(Sun)14:42:21\u2420no.105249282:\u23ce>>105248936\u23ce>says\u2420the\u2420country\u2420that\u2420won\u2420ww2\u23ceFtfy\u2420famalamalam\u23ce\u2026",
+            "gap_bpb": 0.14758298433578715,
+            "model_a_bpb": 0.6823104612153595,
+            "model_a_token_boundaries": "|>>|",
+            "model_b_bpb": 0.5347274768795724,
+            "model_b_token_boundaries": "|>>|",
+            "name": ">>"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 115516,
+            "delta_bits": 1415.5854567856406,
+            "documents": 57758,
+            "example_dataset": "paloma/dolma_100_programing_languages",
+            "example_doc_preview": "\u2026\u2420\u2420S\u2420at\u24201016\u2420in\u2420KITTSKKPN\u2420with\u2420a\u2420score\u2420of\u24200.961\u21b5\u23ce\u2420\u2420T\u2420at\u242010\u2420in\u2420ISEQTGKEL\u2420with\u2420a\u2420score\u2420of\u24200.991\u21b5\u23ce\u2420\u2420T\u2420at\u242035\u2420in\u2420YARVTPDTD\u2420w\u2026",
+            "gap_bpb": 0.012254453554361652,
+            "model_a_bpb": 1.0624514765497546,
+            "model_a_token_boundaries": "|\u2026in|",
+            "model_b_bpb": 1.050197022995393,
+            "model_b_token_boundaries": "|\u2026in|",
+            "name": "in"
+          },
+          {
+            "bucket": "whitespace/newline",
+            "bytes": 81421,
+            "delta_bits": 1285.7193029512348,
+            "documents": 81421,
+            "example_dataset": "paloma/4chan",
+            "example_doc_preview": "\u2026\u23ce\u23ce\u23ceAnonymous\u242002/11/19(Mon)17:23:42\u2420no.202860274:\u23ce>>20285976\u23ceI\u2420thought\u2420he\u2420wasn't\u2420referring\u2420to\u2420slaves.\u23ce\u23ce\u23ceAnonymous\u242002/11\u2026",
+            "gap_bpb": 0.01579100358569945,
+            "model_a_bpb": 1.5670414249558169,
+            "model_a_token_boundaries": "|\u23ce|",
+            "model_b_bpb": 1.5512504213701175,
+            "model_b_token_boundaries": "|\u23ce|",
+            "name": "\u23ce"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 178473,
+            "delta_bits": 1241.966017709975,
+            "documents": 178473,
+            "example_dataset": "paloma/falcon-refinedweb",
+            "example_doc_preview": "\u2026guins,\u2420drafted\u24201st\u2420overall\u2420by\u2420Pittsburgh.\u2420Cap\u2420hit:\u24208,700,00.\u2420Since\u2420he\u2420was\u2420drafted\u2420by\u2420Pittsburgh\u2420and\u2420is\u2420subject\u2420to\u2420the\u2420\u2026",
+            "gap_bpb": 0.00695884541476848,
+            "model_a_bpb": 1.6680162698771677,
+            "model_a_token_boundaries": "|.|",
+            "model_b_bpb": 1.661057424462399,
+            "model_b_token_boundaries": "|.|",
+            "name": "."
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 38211,
+            "delta_bits": 1048.2976072882561,
+            "documents": 38211,
+            "example_dataset": "paloma/mc4",
+            "example_doc_preview": "\u202608:50:19.0016\u24204588\u21e5KeyIso\u2420(c118a82cd78818c29ab228366ebf81c3)\u2420C:\\windows\\system32\\lsass.exe\u23ce08:50:19.0016\u24204588\u21e5KeyIso\u2420-\u2026",
+            "gap_bpb": 0.02743444576923546,
+            "model_a_bpb": 0.8673432204579231,
+            "model_a_token_boundaries": "|)|",
+            "model_b_bpb": 0.8399087746886877,
+            "model_b_token_boundaries": "|)|",
+            "name": ")"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 59323,
+            "delta_bits": 923.1915993778488,
+            "documents": 59323,
+            "example_dataset": "paloma/4chan",
+            "example_doc_preview": "\u2026refrain\u2420from\u2420commenting\u2420on\u2420US\u2420politics\u23ce\u23ce\u23ceAnonymous\u242003/30/17(Thu)10:32:57\u2420no.118925721:\u23ce>>118925654\u23ceThe\u2420dunning-kruger\u2420\u2026",
+            "gap_bpb": 0.015562119234999052,
+            "model_a_bpb": 1.4645556806995217,
+            "model_a_token_boundaries": "|(|",
+            "model_b_bpb": 1.4489935614645226,
+            "model_b_token_boundaries": "|(|",
+            "name": "("
+          },
+          {
+            "bucket": "text/non_ascii",
+            "bytes": 2124,
+            "delta_bits": 846.7512493729309,
+            "documents": 531,
+            "example_dataset": "uncheatable_eval/ao3_english",
+            "example_doc_preview": "\u2026gh\u2420every\u2420part\u2420of\u2420him\u2420as\u2420he\u2420tries\u2420to\u2420scramble\u2420up\u2420in\u2420the\u2420bed.\u201cMum,\u201d\u2420is\u2420all\u2420he\u2420can\u2420manage\u2420between\u2420heaving\u2420breaths\u2420and\u2420han\u2026",
+            "gap_bpb": 0.39865878030740626,
+            "model_a_bpb": 2.372022698096673,
+            "model_a_token_boundaries": "|.\u201c|",
+            "model_b_bpb": 1.973363917789267,
+            "model_b_token_boundaries": "|.\u201c|",
+            "name": ".\u201c"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 12568,
+            "delta_bits": 749.0044233678972,
+            "documents": 12568,
+            "example_dataset": "paloma/4chan",
+            "example_doc_preview": "\u2026tral\u2420version)\u23cehttps://www.youtube.com/watch?v=Gyb\u23ce5XDzLM9o\u23ce[154,180]\u23ce\u23ce\u23ceAnonymous\u242007/29/17(Sat)15:15:36\u2420no.135433319:\u23ceN\u2026",
+            "gap_bpb": 0.05959615080903065,
+            "model_a_bpb": 1.5425085158287215,
+            "model_a_token_boundaries": "|[|",
+            "model_b_bpb": 1.482912365019691,
+            "model_b_token_boundaries": "|[|",
+            "name": "["
+          }
+        ],
+        "model_b_worse": [
+          {
+            "bucket": "whitespace/multi_newline",
+            "bytes": 23724,
+            "delta_bits": -5410.388209869724,
+            "documents": 7908,
+            "example_dataset": "paloma/4chan",
+            "example_doc_preview": "\u2026ymous\u242008/27/17(Sun)14:48:38\u2420no.139250595:\u23ce>>139242946\u23ceRoll\u23ce\u23ce\u23ceAnonymous\u242008/27/17(Sun)14:49:34\u2420no.139250684:\u23ce>>139250406\u2026",
+            "gap_bpb": -0.22805548009904417,
+            "model_a_bpb": 1.8331211162903849,
+            "model_a_token_boundaries": "|\u23ce\u23ce\u23ce|",
+            "model_b_bpb": 2.0611765963894286,
+            "model_b_token_boundaries": "|\u23ce\u23ce\u23ce|",
+            "name": "\u23ce\u23ce\u23ce"
+          },
+          {
+            "bucket": "text/number",
+            "bytes": 16821,
+            "delta_bits": -5297.618015050545,
+            "documents": 16821,
+            "example_dataset": "paloma/m2d2_wikipedia_unsplit",
+            "example_doc_preview": "\u2026ajor\u2420League\u2420Baseball\u2420(MLB)\u2420for\u2420the\u2420Philadelphia\u2420Phillies,\u2420Philadelphia\u2420Athletics\u2420(twice),\u2420and\u2420Cleveland\u2420Naps\u2420between\u24201",
+            "gap_bpb": -0.31494072974558857,
+            "model_a_bpb": 1.3400125025072962,
+            "model_a_token_boundaries": "|1|",
+            "model_b_bpb": 1.6549532322528848,
+            "model_b_token_boundaries": "|1|",
+            "name": "1"
+          },
+          {
+            "bucket": "text/number",
+            "bytes": 13661,
+            "delta_bits": -2898.70739780773,
+            "documents": 13661,
+            "example_dataset": "paloma/dolma_100_programing_languages",
+            "example_doc_preview": "\u202624ONLINE2624\u23ceTIME23:24ONLINE2620\u23ceTIME23:25ONLINE2620\u23ceTIME23:25ONLINE2620\u23ceTIME23:25ONLINE2621\u23ceTIME23:26ONLINE2621\u23ceTIME2",
+            "gap_bpb": -0.2121885219096501,
+            "model_a_bpb": 1.4259324833455638,
+            "model_a_token_boundaries": "|2|",
+            "model_b_bpb": 1.638121005255214,
+            "model_b_token_boundaries": "|2|",
+            "name": "2"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 3752,
+            "delta_bits": -1840.4573701760532,
+            "documents": 469,
+            "example_dataset": "uncheatable_eval/arxiv_physics",
+            "example_doc_preview": "\u2026inferred\u2420from\u2420GravSphere\u2420fit\u2420to\u2420stellar\u2420observations\u23ce\u00a7\u2420Abstract\u2420Dark\u2420matter\u2420mass\u2420density\u2420profiles\u2420and\u2420velocity\u2420distrib\u2026",
+            "gap_bpb": -0.49052701763754086,
+            "model_a_bpb": 0.6991381802056866,
+            "model_a_token_boundaries": "|\u2026Abstract|",
+            "model_b_bpb": 1.1896651978432276,
+            "model_b_token_boundaries": "|\u2026Abstract|",
+            "name": "Abstract"
+          },
+          {
+            "bucket": "text/number",
+            "bytes": 6641,
+            "delta_bits": -1671.4967895641112,
+            "documents": 6641,
+            "example_dataset": "uncheatable_eval/github_cpp",
+            "example_doc_preview": "\u2026\u2420\u2420break;\u21b5\u23ce\u21b5\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420case\u24202:\u21b5\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420std::cout\u2420<<\u2420\"\\n\u2420[3\uc6d0\u2420\ub2f9\ucca8!\u2420\ucd95\ud558\ub4dc\ub9bd\ub2c8\ub2e4!]\u2420\\n\";\u21b5\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420character->setGold(charac\u2026",
+            "gap_bpb": -0.2516935385580652,
+            "model_a_bpb": 2.0186374073982885,
+            "model_a_token_boundaries": "|3|",
+            "model_b_bpb": 2.2703309459563537,
+            "model_b_token_boundaries": "|3|",
+            "name": "3"
+          },
+          {
+            "bucket": "whitespace/mixed",
+            "bytes": 6724,
+            "delta_bits": -1242.2429753424708,
+            "documents": 1681,
+            "example_dataset": "paloma/manosphere_meta_sep",
+            "example_doc_preview": "\u2026ow\u2420to\u2420mount/dismount\u2420from\u2420a\u2420bike.\u2420\u2420Hope\u2420that\u2420helps.\u2420Chris\u2420\u23ce\u23ce\u23ceLola\u2420Z:\u23ce\u2420RE:\u2420Who\u2420Wants\u2420an\u2420Orgasm?\u2420Thank\u2420you!\u2420I\u2420had\u2420not\u2420th\u2026",
+            "gap_bpb": -0.18474761679691712,
+            "model_a_bpb": 2.317790177527492,
+            "model_a_token_boundaries": "|\u2420\u23ce\u23ce\u23ce|",
+            "model_b_bpb": 2.502537794324409,
+            "model_b_token_boundaries": "|\u2420\u23ce\u23ce\u23ce|",
+            "name": "\u2420\u23ce\u23ce\u23ce"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 516924,
+            "delta_bits": -1046.447909980217,
+            "documents": 172308,
+            "example_dataset": "paloma/4chan",
+            "example_doc_preview": "\u20267(Sun)14:23:21\u2420no.105247432:\u23ce>>105247211\u23ce>The\u2420Sherman\u2420had\u2420the\u2420unique\u2420weakness\u2420of\u2420running\u2420on\u2420gasoline\u2420instead\u2420of\u2420diesel\u2026",
+            "gap_bpb": -0.0020243747823281894,
+            "model_a_bpb": 0.46524863161985053,
+            "model_a_token_boundaries": "|\u2026the|",
+            "model_b_bpb": 0.46727300640217867,
+            "model_b_token_boundaries": "|\u2026the|",
+            "name": "the"
+          },
+          {
+            "bucket": "whitespace/tab_or_cr",
+            "bytes": 288,
+            "delta_bits": -1007.032376491354,
+            "documents": 96,
+            "example_dataset": "paloma/manosphere_meta_sep",
+            "example_doc_preview": "\u2026\u2420bench\u2420press\u2420goes\u2420from\u242060kg\u2420x\u242010\u2420to\u242090kg\u2420x\u24205\u2420in\u24202-3\u2420weeks.\u2420\u21b5\u2420At\u2420the\u2420gym\u2420today,\u2420one\u2420of\u2420the\u2420females\u2420who\u2420work\u2420there\u2420had\u2420m\u2026",
+            "gap_bpb": -3.4966401961505347,
+            "model_a_bpb": 4.391290223830126,
+            "model_a_token_boundaries": "|\u2420|\u21b5|\u2420\u2026|",
+            "model_b_bpb": 7.887930419980659,
+            "model_b_token_boundaries": "|\u2420\u21b5|\u2420\u2026|",
+            "name": "\u2420\u21b5\u2420"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 251766,
+            "delta_bits": -973.104078683528,
+            "documents": 83922,
+            "example_dataset": "paloma/m2d2_wikipedia_unsplit",
+            "example_doc_preview": "\u2026-MA-L\"\u2420for\u2420DirecTV\u2420listings.\u2420However,\u2420shortly\u2420after\u2420\"Opie\u2420and\u2420Anthony\"\u2420returned\u2420to\u2420FM\u2420radio,\u2420DirecTV\u2420decided\u2420to\u2420remove\u2026",
+            "gap_bpb": -0.0038651131554043355,
+            "model_a_bpb": 0.7517458742234303,
+            "model_a_token_boundaries": "|\u2026and|",
+            "model_b_bpb": 0.7556109873788347,
+            "model_b_token_boundaries": "|\u2026and|",
+            "name": "and"
+          },
+          {
+            "bucket": "text/number",
+            "bytes": 4450,
+            "delta_bits": -917.8801335251329,
+            "documents": 4450,
+            "example_dataset": "paloma/mc4",
+            "example_doc_preview": "\u2026}.cities-links>li:nth-child(33),.cities-links>li:nth-child(4),.states-links>li:nth-child(29),.states-links>li:nth-chil\u2026",
+            "gap_bpb": -0.2062651985449737,
+            "model_a_bpb": 2.5109720389102352,
+            "model_a_token_boundaries": "|4|",
+            "model_b_bpb": 2.717237237455209,
+            "model_b_token_boundaries": "|4|",
+            "name": "4"
+          },
+          {
+            "bucket": "text/non_ascii",
+            "bytes": 445,
+            "delta_bits": -904.392513672589,
+            "documents": 89,
+            "example_dataset": "uncheatable_eval/arxiv_physics",
+            "example_doc_preview": "\u2026dure\u2420is\u2420to\u2420introduce\u2420fields\u2420on\u2420which\u2420these\u2420act\u2420naturally.\u2420\u00a7.\u00a7\u2420Group\u2420theoretic\u2420formulation\u2420of\u2420the\u2420Stueckelberg\u2420procedur\u2026",
+            "gap_bpb": -2.0323427273541324,
+            "model_a_bpb": 2.9031120712667913,
+            "model_a_token_boundaries": "|\u2026\u00a7|.\u00a7|",
+            "model_b_bpb": 4.935454798620923,
+            "model_b_token_boundaries": "|\u2026\u00a7|.\u00a7|",
+            "name": "\u00a7.\u00a7"
+          },
+          {
+            "bucket": "text/number",
+            "bytes": 3475,
+            "delta_bits": -837.8520467191637,
+            "documents": 3475,
+            "example_dataset": "paloma/m2d2_s2orc_unsplit",
+            "example_doc_preview": "\u2026he\u2420impulse\u2420propagation\u2420in\u2420biological\u2420networks\u2420[33,\u242057,\u242060,\u24205,\u24206]\u2420.\u2420Time-lapse\u2420snapshots\u2420provided\u2420in\u2420the\u2420paper\u2420were\u2420rec\u2026",
+            "gap_bpb": -0.24110850265299674,
+            "model_a_bpb": 2.783026517060763,
+            "model_a_token_boundaries": "|5|",
+            "model_b_bpb": 3.0241350197137593,
+            "model_b_token_boundaries": "|5|",
+            "name": "5"
+          }
+        ]
+      },
+      "top_segments": {
+        "model_a_worse": [
+          {
+            "bucket": "text/url",
+            "bytes": 89,
+            "dataset": "paloma/mc4",
+            "delta_bits": 198.375584856166,
+            "doc_preview": "\u2026oto-Bold\"),url(https://fonts.gstatic.com/s/roboto/v16/isZ-wbCXNKAbnjo6_TwHToX0hVgzZQUfRDuZrPvH3D8.woff2)\u2420format(\"woff2\u2026",
+            "gap_bpb": 2.2289391556872586,
+            "text": "https://fonts.gstatic.com/s/rob\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 407,
+            "dataset": "paloma/mc4",
+            "delta_bits": 183.83228352430092,
+            "doc_preview": "\u2026images.webfronts.com/cache/frbovyedvsks.jpg?imgeng=/w_300','https://images.webfronts.com/cache/freefsindllm.jpg?imgeng\u2026",
+            "gap_bpb": 0.45167637229557966,
+            "text": "https://images.webfronts.com/ca\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 67,
+            "dataset": "paloma/mc4",
+            "delta_bits": 155.30545674831222,
+            "doc_preview": "\u2026ions:\u2420[\u2420],\u2420image_urls:\u2420[\u2420'https://images.webfronts.com/cache/frdhoekgmqoe.jpg?imgeng=/w_300',\u2420'https://images.webfront\u2026",
+            "gap_bpb": 2.317991891765854,
+            "text": "https://images.webfronts.com/ca\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 69,
+            "dataset": "paloma/mc4",
+            "delta_bits": 127.61139187947241,
+            "doc_preview": "\u2026ff2)\u2420format(\"woff2\"),url(https://fonts.gstatic.com/s/roboto/v20/KFOlCnqEu92Fr1MmWUlfBBc-.woff)\u2420format(\"woff\");unicode-\u2026",
+            "gap_bpb": 1.8494404620213392,
+            "text": "https://fonts.gstatic.com/s/rob\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 89,
+            "dataset": "paloma/mc4",
+            "delta_bits": 111.72036041259032,
+            "doc_preview": "\u2026oto-Bold\"),url(https://fonts.gstatic.com/s/roboto/v16/d-6IYplOFocCacKzxwXSOJBw1xU1rKptJj_0jans920.woff2)\u2420format(\"woff2\u2026",
+            "gap_bpb": 1.255284948456071,
+            "text": "https://fonts.gstatic.com/s/rob\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 52,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": 95.1146770887493,
+            "doc_preview": "\u2026ler)\u23ce-\u2420[adamh-html_render\u24200.0.8](https://github.com/docker-rubygem/adamh-html_render)\u23ce-\u2420[adamh-ruby-prof\u24200.7.3](https:\u2026",
+            "gap_bpb": 1.8291284055528712,
+            "text": "https://github.com/docker-rubyg\u2026"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 36,
+            "dataset": "paloma/redpajama",
+            "delta_bits": 75.2193998496598,
+            "doc_preview": "\u2026e\u2420Brillouin\u2420zone\u2420shown\u2420in\u2420Fig.\\\u2420\\ref{Fig:Lattice_Structure_and_Brillouin_Zone}\u2420(b),\u2420where\u2420the\u2420Fermi\u2420level\u2420is\u2420located.\\\u2026",
+            "gap_bpb": 2.089427773601661,
+            "text": "Lattice_Structure_and_Brillouin\u2026"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 9,
+            "dataset": "paloma/mc4",
+            "delta_bits": 63.536085574291576,
+            "doc_preview": "\u2026dows\\System32\\drivers\\mshidkmdf.sys\u23ce08:50:22.0697\u24204588\u21e5mshidkmdf\u2420-\u2420ok\u23ce08:50:22.0744\u24204588\u21e5msisadrv\u2420(d916874bbd4f8b07bfb\u2026",
+            "gap_bpb": 7.059565063810175,
+            "text": "mshidkmdf"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 25,
+            "dataset": "paloma/mc4",
+            "delta_bits": 63.16333072077945,
+            "doc_preview": "\u2026nd/dan/Danby.html',\u2420request_quote_link:\u2420`/_CGI/ADD_ITEM_TO_QUOTE_BUILDER.HTML?KEY=DAN:DUFM085A4WDD`,\u2420add_to_cart_link:\u2026",
+            "gap_bpb": 2.526533228831178,
+            "text": "ADD_ITEM_TO_QUOTE_BUILDER"
+          },
+          {
+            "bucket": "text/number",
+            "bytes": 21,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": 62.893407857478664,
+            "doc_preview": "\u2026,278\u23ce190,3696,1068,135,278\u23ce191,3699,1068,135,278\u23ce192,3700,1068,135,278\u23ce193,3705,1068,135,278\u23ce194,3704,1068,135,278\u23ce195\u2026",
+            "gap_bpb": 2.9949241836894602,
+            "text": "192,3700,1068,135,278"
+          },
+          {
+            "bucket": "text/number",
+            "bytes": 22,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": 62.05162437465924,
+            "doc_preview": "\u2026:20ONLINE2898\u23ce1627406473890:20976156:\u4e3a\u4ec0\u4e48\u9b54\u6cd5\u9700\u8981\u71c3\u6599\uff08\u23ce1627406480610:20976156:\u4e4b\u7c7b\u7684\u23ceTIME1:21ONLINE2888\u23ce1627406505358:20976156:\u5408\u2026",
+            "gap_bpb": 2.820528380666329,
+            "text": "1627406480610:20976156"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 32,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": 59.325257191088355,
+            "doc_preview": "\u2026ist_fonts_reply\u2420xcb_list_fonts_reply_impl;\u23cetxcb_list_fonts_with_info_sizeof\u2420xcb_list_fonts_with_info_sizeof_impl;\u23cetxcb\u2026",
+            "gap_bpb": 1.853914287221511,
+            "text": "txcb_list_fonts_with_info_sizeof"
+          }
+        ],
+        "model_b_worse": [
+          {
+            "bucket": "text/url",
+            "bytes": 72,
+            "dataset": "paloma/mc4",
+            "delta_bits": -187.333907001775,
+            "doc_preview": "\u2026cal(\"Roboto-Thin\"),url(https://fonts.gstatic.com/s/roboto/v20/KFOkCnqEu92Fr1MmgVxMIzIFKw.woff2)\u2420format(\"woff2\");unicod\u2026",
+            "gap_bpb": -2.601859819469097,
+            "text": "https://fonts.gstatic.com/s/rob\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 89,
+            "dataset": "paloma/mc4",
+            "delta_bits": -169.50228865865023,
+            "doc_preview": "\u2026to-Black\"),url(https://fonts.gstatic.com/s/roboto/v16/s7gftie1JANC-QmDJvMWZoX0hVgzZQUfRDuZrPvH3D8.woff2)\u2420format(\"woff2\u2026",
+            "gap_bpb": -1.9045200972882048,
+            "text": "https://fonts.gstatic.com/s/rob\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 67,
+            "dataset": "paloma/mc4",
+            "delta_bits": -149.25637833030822,
+            "doc_preview": "\u2026ions:\u2420[\u2420],\u2420image_urls:\u2420[\u2420'https://images.webfronts.com/cache/frhtxpvaylak.jpg?imgeng=/w_300',\u2420'https://images.webfront\u2026",
+            "gap_bpb": -2.2277071392583316,
+            "text": "https://images.webfronts.com/ca\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 67,
+            "dataset": "paloma/mc4",
+            "delta_bits": -134.79119862081762,
+            "doc_preview": "\u2026ions:\u2420[\u2420],\u2420image_urls:\u2420[\u2420'https://images.webfronts.com/cache/frskfdklvcqv.jpg?imgeng=/w_300',\u2420'https://images.webfront\u2026",
+            "gap_bpb": -2.011808934639069,
+            "text": "https://images.webfronts.com/ca\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 135,
+            "dataset": "paloma/mc4",
+            "delta_bits": -126.27269290629403,
+            "doc_preview": "\u2026images.webfronts.com/cache/frpccopatfdq.jpg?imgeng=/w_300','https://images.webfronts.com/cache/frrxvbnhshef.jpg?imgeng\u2026",
+            "gap_bpb": -0.9353532807873631,
+            "text": "https://images.webfronts.com/ca\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 89,
+            "dataset": "paloma/mc4",
+            "delta_bits": -117.10298456472928,
+            "doc_preview": "\u2026to-Black\"),url(https://fonts.gstatic.com/s/roboto/v16/mnpfi9pxYH-Go5UiibESIpBw1xU1rKptJj_0jans920.woff2)\u2420format(\"woff2\u2026",
+            "gap_bpb": -1.3157638715138122,
+            "text": "https://fonts.gstatic.com/s/rob\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 49,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": -94.65552782546126,
+            "doc_preview": "\u2026em/akane)\u23ce-\u2420[akane-bigquery\u24200.1.0](https://github.com/docker-rubygem/akane-bigquery)\u23ce-\u2420[akapen\u24200.0.1](https://github.c\u2026",
+            "gap_bpb": -1.93174546582574,
+            "text": "https://github.com/docker-rubyg\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 89,
+            "dataset": "paloma/mc4",
+            "delta_bits": -79.83859337873564,
+            "doc_preview": "\u2026to-Black\"),url(https://fonts.gstatic.com/s/roboto/v16/3Y_xCyt7TNunMGg0Et2pnoX0hVgzZQUfRDuZrPvH3D8.woff2)\u2420format(\"woff2\u2026",
+            "gap_bpb": -0.8970628469520858,
+            "text": "https://fonts.gstatic.com/s/rob\u2026"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 25,
+            "dataset": "paloma/4chan",
+            "delta_bits": -61.67753235603797,
+            "doc_preview": "\u2026\u23ce/ng-interactive/2016/nov/08/us-elec\u23cetion-2016-results-live-clinton-trum\u23cep?view=map&type=presidential\u23ce\u23ce\u23ceAnonymous\u242011/0\u2026",
+            "gap_bpb": -2.4671012942415187,
+            "text": "results-live-clinton-trum"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 15,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": -56.85007118505055,
+            "doc_preview": "\u2026https://github.com/docker-rubygem/adammck-pants)\u23ce-\u2420[adammck-rubygsm\u24200.41](https://github.com/docker-rubygem/adammck-ru\u2026",
+            "gap_bpb": -3.790004745670037,
+            "text": "adammck-rubygsm"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 25,
+            "dataset": "paloma/mc4",
+            "delta_bits": -54.59368597900115,
+            "doc_preview": "\u2026nd/dan/Danby.html',\u2420request_quote_link:\u2420`/_CGI/ADD_ITEM_TO_QUOTE_BUILDER.HTML?KEY=DAN:DUFM101A2WDD`,\u2420add_to_cart_link:\u2026",
+            "gap_bpb": -2.183747439160046,
+            "text": "ADD_ITEM_TO_QUOTE_BUILDER"
+          },
+          {
+            "bucket": "text/number",
+            "bytes": 21,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": -52.90064983668854,
+            "doc_preview": "\u2026833923:1875520:\u554a\u2420\u5e94\u8be5\u5728\u5927\u4e71\u6597\u7684\u65f6\u5019\u5f00\u7684\u23ceTIME21:10ONLINE3861\u23ce1627477881583:7614937:\u90a3\u5565\u65f6\u5019\u8dd1\u56e2\u634f\u23ceTIME21:11ONLINE3861\u23ce1627477888214:18755\u2026",
+            "gap_bpb": -2.519078563651835,
+            "text": "1627477881583:7614937"
+          }
+        ]
+      },
+      "uncheatable_gap_bpb": 0.001962093569215558,
+      "wins": 14
+    },
+    {
+      "baseline": "llama3-128k",
+      "biggest_losses": [
+        {
+          "bytes": 32768,
+          "delta_bits": 1627.5184100223423,
+          "documents": 1,
+          "gap_bpb": 0.049667920227732615,
+          "model_a_bpb": 1.1841866476684357,
+          "model_b_bpb": 1.1345187274407031,
+          "name": "paloma/ptb"
+        },
+        {
+          "bytes": 204005,
+          "delta_bits": 7350.381165178043,
+          "documents": 256,
+          "gap_bpb": 0.036030397123492285,
+          "model_a_bpb": 1.1659954179033605,
+          "model_b_bpb": 1.1299650207798682,
+          "name": "paloma/dolma_100_subreddits"
+        },
+        {
+          "bytes": 987693,
+          "delta_bits": 27263.54494949567,
+          "documents": 59,
+          "gap_bpb": 0.0276032582487632,
+          "model_a_bpb": 0.9897471595557117,
+          "model_b_bpb": 0.9621439013069485,
+          "name": "paloma/wikitext_103"
+        },
+        {
+          "bytes": 841249,
+          "delta_bits": 20471.897682642746,
+          "documents": 256,
+          "gap_bpb": 0.024335122755144725,
+          "model_a_bpb": 0.9484334408758154,
+          "model_b_bpb": 0.9240983181206707,
+          "name": "uncheatable_eval/bbc_news"
+        },
+        {
+          "bytes": 1223044,
+          "delta_bits": 28288.47935984479,
+          "documents": 256,
+          "gap_bpb": 0.023129567995791477,
+          "model_a_bpb": 1.137822235736893,
+          "model_b_bpb": 1.1146926677411015,
+          "name": "uncheatable_eval/ao3_english"
+        }
+      ],
+      "biggest_wins": [
+        {
+          "bytes": 37599,
+          "delta_bits": -1001.1453658649391,
+          "documents": 256,
+          "gap_bpb": -0.02662691470158619,
+          "model_a_bpb": 1.647422102103921,
+          "model_b_bpb": 1.6740490168055073,
+          "name": "paloma/gab"
+        },
+        {
+          "bytes": 9649,
+          "delta_bits": -246.3365083195324,
+          "documents": 256,
+          "gap_bpb": -0.025529744877140888,
+          "model_a_bpb": 2.7181020419212625,
+          "model_b_bpb": 2.7436317867984035,
+          "name": "paloma/twitterAAE_HELM_fixed"
+        },
+        {
+          "bytes": 876685,
+          "delta_bits": -11495.787100284091,
+          "documents": 256,
+          "gap_bpb": -0.013112790911540738,
+          "model_a_bpb": 0.6264642437855025,
+          "model_b_bpb": 0.6395770346970432,
+          "name": "uncheatable_eval/github_cpp"
+        },
+        {
+          "bytes": 898445,
+          "delta_bits": -10837.091589498285,
+          "documents": 256,
+          "gap_bpb": -0.012062053425082542,
+          "model_a_bpb": 0.6484289815940305,
+          "model_b_bpb": 0.6604910350191131,
+          "name": "paloma/dolma_100_programing_languages"
+        },
+        {
+          "bytes": 1067444,
+          "delta_bits": -8357.08350319879,
+          "documents": 256,
+          "gap_bpb": -0.007829060356514057,
+          "model_a_bpb": 1.156108047951749,
+          "model_b_bpb": 1.1639371083082628,
+          "name": "paloma/4chan"
+        }
+      ],
+      "bytes": 23108960,
+      "dataset_groups": [
+        {
+          "bytes": 16006023,
+          "delta_bits": 136727.1336783918,
+          "documents": 3348,
+          "gap_bpb": 0.008542230239103856,
+          "model_a_bpb": 0.9888621694112919,
+          "model_b_bpb": 0.9803199391721881,
+          "name": "paloma"
+        },
+        {
+          "bytes": 7102937,
+          "delta_bits": 49696.13563087228,
+          "documents": 1792,
+          "gap_bpb": 0.006996561511227297,
+          "model_a_bpb": 0.8655142214645501,
+          "model_b_bpb": 0.8585176599533229,
+          "name": "uncheatable_eval"
+        }
+      ],
+      "datasets": [
+        {
+          "bytes": 1067444,
+          "delta_bits": -8357.08350319879,
+          "documents": 256,
+          "gap_bpb": -0.007829060356514057,
+          "model_a_bpb": 1.156108047951749,
+          "model_b_bpb": 1.1639371083082628,
+          "name": "paloma/4chan"
+        },
+        {
+          "bytes": 744402,
+          "delta_bits": 7735.855562704461,
+          "documents": 256,
+          "gap_bpb": 0.01039204027219763,
+          "model_a_bpb": 1.0116207799439478,
+          "model_b_bpb": 1.0012287396717503,
+          "name": "paloma/c4_100_domains"
+        },
+        {
+          "bytes": 523373,
+          "delta_bits": 9280.791791452624,
+          "documents": 256,
+          "gap_bpb": 0.01773265298640286,
+          "model_a_bpb": 0.9956927615812929,
+          "model_b_bpb": 0.9779601085948901,
+          "name": "paloma/c4_en"
+        },
+        {
+          "bytes": 858825,
+          "delta_bits": 11990.608926998737,
+          "documents": 256,
+          "gap_bpb": 0.013961644021772465,
+          "model_a_bpb": 1.0444265617623425,
+          "model_b_bpb": 1.03046491774057,
+          "name": "paloma/dolma-v1_5"
+        },
+        {
+          "bytes": 898445,
+          "delta_bits": -10837.091589498285,
+          "documents": 256,
+          "gap_bpb": -0.012062053425082542,
+          "model_a_bpb": 0.6484289815940305,
+          "model_b_bpb": 0.6604910350191131,
+          "name": "paloma/dolma_100_programing_languages"
+        },
+        {
+          "bytes": 204005,
+          "delta_bits": 7350.381165178043,
+          "documents": 256,
+          "gap_bpb": 0.036030397123492285,
+          "model_a_bpb": 1.1659954179033605,
+          "model_b_bpb": 1.1299650207798682,
+          "name": "paloma/dolma_100_subreddits"
+        },
+        {
+          "bytes": 700803,
+          "delta_bits": 8513.425464299735,
+          "documents": 256,
+          "gap_bpb": 0.012148100770544267,
+          "model_a_bpb": 1.044005142860306,
+          "model_b_bpb": 1.0318570420897617,
+          "name": "paloma/falcon-refinedweb"
+        },
+        {
+          "bytes": 37599,
+          "delta_bits": -1001.1453658649391,
+          "documents": 256,
+          "gap_bpb": -0.02662691470158619,
+          "model_a_bpb": 1.647422102103921,
+          "model_b_bpb": 1.6740490168055073,
+          "name": "paloma/gab"
+        },
+        {
+          "bytes": 5472253,
+          "delta_bits": 61474.34302500527,
+          "documents": 167,
+          "gap_bpb": 0.011233826912791728,
+          "model_a_bpb": 0.9562815539082201,
+          "model_b_bpb": 0.9450477269954284,
+          "name": "paloma/m2d2_s2orc_unsplit"
+        },
+        {
+          "bytes": 1605632,
+          "delta_bits": 10734.779353768368,
+          "documents": 49,
+          "gap_bpb": 0.0066857034200665955,
+          "model_a_bpb": 0.9618976400333775,
+          "model_b_bpb": 0.9552119366133109,
+          "name": "paloma/m2d2_wikipedia_unsplit"
+        },
+        {
+          "bytes": 1000476,
+          "delta_bits": 3715.2523677007184,
+          "documents": 256,
+          "gap_bpb": 0.0037134847489602133,
+          "model_a_bpb": 1.184142772154659,
+          "model_b_bpb": 1.1804292874056987,
+          "name": "paloma/manosphere_meta_sep"
+        },
+        {
+          "bytes": 974819,
+          "delta_bits": -6043.176140873537,
+          "documents": 256,
+          "gap_bpb": -0.006199280215992443,
+          "model_a_bpb": 0.962039386703145,
+          "model_b_bpb": 0.9682386669191374,
+          "name": "paloma/mc4"
+        },
+        {
+          "bytes": 32768,
+          "delta_bits": 1627.5184100223423,
+          "documents": 1,
+          "gap_bpb": 0.049667920227732615,
+          "model_a_bpb": 1.1841866476684357,
+          "model_b_bpb": 1.1345187274407031,
+          "name": "paloma/ptb"
+        },
+        {
+          "bytes": 887837,
+          "delta_bits": 13525.465769516852,
+          "documents": 256,
+          "gap_bpb": 0.015234176734599765,
+          "model_a_bpb": 0.9752955201912882,
+          "model_b_bpb": 0.9600613434566884,
+          "name": "paloma/redpajama"
+        },
+        {
+          "bytes": 9649,
+          "delta_bits": -246.3365083195324,
+          "documents": 256,
+          "gap_bpb": -0.025529744877140888,
+          "model_a_bpb": 2.7181020419212625,
+          "model_b_bpb": 2.7436317867984035,
+          "name": "paloma/twitterAAE_HELM_fixed"
+        },
+        {
+          "bytes": 987693,
+          "delta_bits": 27263.54494949567,
+          "documents": 59,
+          "gap_bpb": 0.0276032582487632,
+          "model_a_bpb": 0.9897471595557117,
+          "model_b_bpb": 0.9621439013069485,
+          "name": "paloma/wikitext_103"
+        },
+        {
+          "bytes": 1223044,
+          "delta_bits": 28288.47935984479,
+          "documents": 256,
+          "gap_bpb": 0.023129567995791477,
+          "model_a_bpb": 1.137822235736893,
+          "model_b_bpb": 1.1146926677411015,
+          "name": "uncheatable_eval/ao3_english"
+        },
+        {
+          "bytes": 1237838,
+          "delta_bits": 617.0745817479133,
+          "documents": 256,
+          "gap_bpb": 0.0004985099679828163,
+          "model_a_bpb": 0.8418473613299623,
+          "model_b_bpb": 0.8413488513619795,
+          "name": "uncheatable_eval/arxiv_computer_science"
+        },
+        {
+          "bytes": 1282105,
+          "delta_bits": 6846.497588842468,
+          "documents": 256,
+          "gap_bpb": 0.0053400443714379615,
+          "model_a_bpb": 0.9094822120462195,
+          "model_b_bpb": 0.9041421676747816,
+          "name": "uncheatable_eval/arxiv_physics"
+        },
+        {
+          "bytes": 841249,
+          "delta_bits": 20471.897682642746,
+          "documents": 256,
+          "gap_bpb": 0.024335122755144725,
+          "model_a_bpb": 0.9484334408758154,
+          "model_b_bpb": 0.9240983181206707,
+          "name": "uncheatable_eval/bbc_news"
+        },
+        {
+          "bytes": 876685,
+          "delta_bits": -11495.787100284091,
+          "documents": 256,
+          "gap_bpb": -0.013112790911540738,
+          "model_a_bpb": 0.6264642437855025,
+          "model_b_bpb": 0.6395770346970432,
+          "name": "uncheatable_eval/github_cpp"
+        },
+        {
+          "bytes": 1006410,
+          "delta_bits": -2663.9750573168985,
+          "documents": 256,
+          "gap_bpb": -0.002647007737718125,
+          "model_a_bpb": 0.5798798613253224,
+          "model_b_bpb": 0.5825268690630405,
+          "name": "uncheatable_eval/github_python"
+        },
+        {
+          "bytes": 635606,
+          "delta_bits": 7631.948575396027,
+          "documents": 256,
+          "gap_bpb": 0.012007357664018318,
+          "model_a_bpb": 0.9711780618021691,
+          "model_b_bpb": 0.9591707041381508,
+          "name": "uncheatable_eval/wikipedia_english"
+        }
+      ],
+      "documents": 5140,
+      "examples": {
+        "model_a_worse": [
+          {
+            "bytes": 32768,
+            "dataset": "paloma/m2d2_s2orc_unsplit",
+            "gap_bpb": 0.14056017105523216,
+            "model_a_bpb": 1.103763041086976,
+            "model_b_bpb": 0.9632028700317439,
+            "preview": "\u2026\u2420using\u2420the\u2420function\u2420recmap2sp\u2420the\u2420recmap\u2420class\u2420can\u2420be\u2420transformed\u2420into\u2420a\u2420SpatialPolygonsDataFrame\u2420object.\u2420The\u2420followin\u2026",
+            "row_index": 0,
+            "shard": "stat_l1_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": 3.2479616653399686,
+            "worst_text": "transformed"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/m2d2_s2orc_unsplit",
+            "gap_bpb": 0.14056017105523216,
+            "model_a_bpb": 1.103763041086976,
+            "model_b_bpb": 0.9632028700317439,
+            "preview": "\u2026\u2420using\u2420the\u2420function\u2420recmap2sp\u2420the\u2420recmap\u2420class\u2420can\u2420be\u2420transformed\u2420into\u2420a\u2420SpatialPolygonsDataFrame\u2420object.\u2420The\u2420followin\u2026",
+            "row_index": 0,
+            "shard": "stat_CO_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": 3.2479616653399686,
+            "worst_text": "transformed"
+          },
+          {
+            "bytes": 32441,
+            "dataset": "paloma/redpajama",
+            "gap_bpb": 0.12516101096666374,
+            "model_a_bpb": 1.0590597125642671,
+            "model_b_bpb": 0.9338987015976034,
+            "preview": "\u2026e\u2420Brillouin\u2420zone\u2420shown\u2420in\u2420Fig.\\\u2420\\ref{Fig:Lattice_Structure_and_Brillouin_Zone}\u2420(b),\u2420where\u2420the\u2420Fermi\u2420level\u2420is\u2420located.\\\u2026",
+            "row_index": 7,
+            "shard": "arxiv_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": 2.1233991609244023,
+            "worst_text": "Lattice_Structure_and_Brillouin\u2026"
+          },
+          {
+            "bytes": 17487,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "gap_bpb": 0.11133423659072181,
+            "model_a_bpb": 0.7779695613691786,
+            "model_b_bpb": 0.6666353247784568,
+            "preview": "\u2026\"WHERE\u2420name\u2420=\u2420?\u2420AND\u2420age\u2420=\u2420?\":@[@\"John\",@\"17\"]}\u3002\u8981\u4fdd\u8bc1where\u5b57\u5178\u6709\u4e14\u4ec5\u6709\u4e00\u7ec4key-value\u23ce@return\u2420\u8bb0\u5f55\u6570\u76ee\u23ce*/\u23ce-\u2420(int)itemCountForTable:(NSS\u2026",
+            "row_index": 42,
+            "shard": "01_markdown_jsonl_gz",
+            "worst_bucket": "text/non_ascii_word",
+            "worst_gap_bpb": 1.7924704168427341,
+            "worst_text": "\u8981\u4fdd\u8bc1where\u5b57\u5178\u6709\u4e14\u4ec5\u6709\u4e00\u7ec4key-value"
+          },
+          {
+            "bytes": 13783,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "gap_bpb": 0.1369214085855113,
+            "model_a_bpb": 0.8020057085981912,
+            "model_b_bpb": 0.6650843000126799,
+            "preview": "\u2026overed\u21e5Execution\u2420time\u21e5#\u2420of\u2420failed\u2420execution\u21e5#\u2420of\u2420total\u2420execution\u21b51\u21e5AccessibleExtendedTable,\u2420AccessibleHypertext,\u2420Acces\u2026",
+            "row_index": 15,
+            "shard": "00_text_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": 3.480072066471349,
+            "worst_text": "execution"
+          },
+          {
+            "bytes": 24241,
+            "dataset": "paloma/manosphere_meta_sep",
+            "gap_bpb": 0.07597682498105522,
+            "model_a_bpb": 1.0518461095454372,
+            "model_b_bpb": 0.9758692845643822,
+            "preview": "\u2026re\u2420every\u2420bit\u2420as\u2420selfish\u2420and\u2420immoral\u2420as\u2420your\u2420average\u2420r/cuckqueers\u2420poster.\u2420It\u2420is\u2420time\u2420for\u2420you\u2420to\u2420take\u2420the\u2420real\u2420racepill\u2420\u2026",
+            "row_index": 4,
+            "shard": "incels_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": 3.376949718113304,
+            "worst_text": "cuckqueers"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/ptb",
+            "gap_bpb": 0.049667920227732615,
+            "model_a_bpb": 1.1841866476684357,
+            "model_b_bpb": 1.1345187274407031,
+            "preview": "\u2026ns\u2420of\u2420dollars\u2420while\u2420<unk>\u2420severe\u2420pay\u2420cuts\u2420on\u2420the\u2420<unk>\u2420employees\u2420of\u2420united\u2420is\u2420not\u2420only\u2420<unk>\u2420but\u2420<unk>\u2420\u23ce\u2420the\u2420machinist\u2026",
+            "row_index": 0,
+            "shard": "val_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": 3.772565811883363,
+            "worst_text": "employees"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/mc4",
+            "gap_bpb": 0.04604404106843315,
+            "model_a_bpb": 1.0332863982511347,
+            "model_b_bpb": 0.9872423571827015,
+            "preview": "\u2026New\u2420colors\u2420Embroidery\u2420Floss\u24208.7yd-Rosewood\u2420from\u2420Walmart\u2420Canada\u2420Walmart.com,\u2420are!\u2420Is\u2420great\u2420for\u2420Cross\u2420Stitch\u2420and\u2420Embroid\u2026",
+            "row_index": 160,
+            "shard": "0_jsonl_gz",
+            "worst_bucket": "text/word",
+            "worst_gap_bpb": 6.547854383738422,
+            "worst_text": "Canada"
+          }
+        ],
+        "model_b_worse": [
+          {
+            "bytes": 17096,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "gap_bpb": -0.18363260972402934,
+            "model_a_bpb": 1.168572881201409,
+            "model_b_bpb": 1.3522054909254382,
+            "preview": "\u2026\u0646\"}\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420ga{\"\u0622\u0626\u06cc\u0631\u0650\u0634\"}\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420gaa{\"\u06af\u0627\"}\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420gag{\"\u063a\u0627\u063a\u0627\u0648\u0632\"}\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420gd{\"\u0633\u06a9\u0627\u0679\u2420\u06af\u06cc\u0644\u0650\u06a9\"}\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420gl{\"\u06af\u0627\u0644\u06cc\u0634\u06cc\u0627\u0626\u06cc\"}\u23ce\u2420\u2420\u2420\u2420\u2026",
+            "row_index": 31,
+            "shard": "00_text_jsonl_gz",
+            "worst_bucket": "text/non_ascii_word",
+            "worst_gap_bpb": -2.7596127537788124,
+            "worst_text": "\u063a\u0627\u063a\u0627\u0648\u0632"
+          },
+          {
+            "bytes": 29024,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "gap_bpb": -0.08211915235980743,
+            "model_a_bpb": 0.545867214367005,
+            "model_b_bpb": 0.6279863667268125,
+            "preview": "\u2026201~\u21b5\u23ce~03003~^~315~^~S2113~\u21b5\u23ce~03003~^~341~^~S2113~\u21b5\u23ce~03003~^~406~^~S2113~\u21b5\u23ce~03003~^~629~^~S2113~\u21b5\u23ce~03003~^~653~^~S2113\u2026",
+            "row_index": 26,
+            "shard": "00_text_jsonl_gz",
+            "worst_bucket": "text/punctuation",
+            "worst_gap_bpb": -9.848036572800714,
+            "worst_text": "~^~"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/mc4",
+            "gap_bpb": -0.05571679110644237,
+            "model_a_bpb": 1.3648679612270331,
+            "model_b_bpb": 1.4205847523334756,
+            "preview": "\u2026F2DBCE5F-27E0-4B2E-9BD6-69FE163CCA4C}\\3525020527F6A65636470225563747F627164796F6E637\u2420:\u2420DhcpNameServer\u2420=\u2420192.168.2.1\u23ceTC\u2026",
+            "row_index": 122,
+            "shard": "0_jsonl_gz",
+            "worst_bucket": "text/number",
+            "worst_gap_bpb": -4.0631847272084265,
+            "worst_text": "65636470225563747"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "gap_bpb": -0.049072521991943625,
+            "model_a_bpb": 0.5297974067007544,
+            "model_b_bpb": 0.5788699286926979,
+            "preview": "\u2026int64_t\u2420x219\u2420=\u2420INT64_MIN;\u23ce\u21e5static\u2420int64_t\u2420x220\u2420=\u2420-119442428141593093LL;\u23ce\u21e5int64_t\u2420t45\u2420=\u2420|||PHONE_NUMBER|||\u2420913037LL;\u23ce\u23ce\u2420\u2026",
+            "row_index": 14,
+            "shard": "02_c_jsonl_gz",
+            "worst_bucket": "text/number",
+            "worst_gap_bpb": -3.8467961688666272,
+            "worst_text": "119442428141593093"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "gap_bpb": -0.03960850740759101,
+            "model_a_bpb": 0.891979989321901,
+            "model_b_bpb": 0.9315884967294921,
+            "preview": "\u20268ONLINE3076\u23ceTIME0:59ONLINE3076\u23ce1627405150457:20976156:\u8bdd\u8bf4\u6c38\u52ab\u591a\u5c11\u5206\u4e0a\u6bb5\u554a\u23ceTIME0:59ONLINE3068\u23ce1627405181489:20976156:\u90a3\u76ee\u6807\u5c31\u662f4000\u23ce1\u2026",
+            "row_index": 22,
+            "shard": "00_text_jsonl_gz",
+            "worst_bucket": "text/non_ascii_word",
+            "worst_gap_bpb": -2.583571220206105,
+            "worst_text": "\u8bdd\u8bf4\u6c38\u52ab\u591a\u5c11\u5206\u4e0a\u6bb5\u554a"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/mc4",
+            "gap_bpb": -0.03937014382668497,
+            "model_a_bpb": 0.5970748523707746,
+            "model_b_bpb": 0.6364449961974596,
+            "preview": "\u2026ions:\u2420[\u2420],\u2420image_urls:\u2420[\u2420'https://images.webfronts.com/cache/frskfdklvcqv.jpg?imgeng=/w_300',\u2420'https://images.webfront\u2026",
+            "row_index": 45,
+            "shard": "0_jsonl_gz",
+            "worst_bucket": "text/url",
+            "worst_gap_bpb": -2.990730406657127,
+            "worst_text": "https://images.webfronts.com/ca\u2026"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/mc4",
+            "gap_bpb": -0.03917463493212811,
+            "model_a_bpb": 0.7444474824073899,
+            "model_b_bpb": 0.783622117339518,
+            "preview": "\u2026to\u2420include\u2420a\u2420number...http://www.google.com/patents/US20100006902?utm_source=gb-gplus-sharePatent\u2420US20100006902\u2420-\u2420Semi\u2026",
+            "row_index": 197,
+            "shard": "0_jsonl_gz",
+            "worst_bucket": "text/url",
+            "worst_gap_bpb": -0.6647351021096649,
+            "worst_text": "http://www.google.com/patents/U\u2026"
+          },
+          {
+            "bytes": 32768,
+            "dataset": "paloma/mc4",
+            "gap_bpb": -0.034635647706100114,
+            "model_a_bpb": 0.6777387005322522,
+            "model_b_bpb": 0.7123743482383522,
+            "preview": "\u2026to-Black\"),url(https://fonts.gstatic.com/s/roboto/v16/mnpfi9pxYH-Go5UiibESIpBw1xU1rKptJj_0jans920.woff2)\u2420format(\"woff2\u2026",
+            "row_index": 155,
+            "shard": "0_jsonl_gz",
+            "worst_bucket": "text/url",
+            "worst_gap_bpb": -3.01469409868597,
+            "worst_text": "https://fonts.gstatic.com/s/rob\u2026"
+          }
+        ]
+      },
+      "label": "TokenMonster English/code, 32k vocab",
+      "losses": 16,
+      "model": "tokenmonster-englishcode-32k",
+      "overall_gap_bpb": 0.008067142325282519,
+      "paloma_gap_bpb": 0.008542230239103856,
+      "pattern_buckets": [
+        {
+          "bytes": 110850,
+          "delta_bits": -8160.089090054075,
+          "documents": 33576,
+          "gap_bpb": -0.07361379422691994,
+          "model_a_bpb": 1.3409473704776476,
+          "model_b_bpb": 1.4145611647045673,
+          "name": "text/non_ascii"
+        },
+        {
+          "bytes": 243363,
+          "delta_bits": -33731.05254623289,
+          "documents": 36486,
+          "gap_bpb": -0.13860386560912252,
+          "model_a_bpb": 1.1736597475652222,
+          "model_b_bpb": 1.3122636131743446,
+          "name": "text/non_ascii_word"
+        },
+        {
+          "bytes": 581666,
+          "delta_bits": -189022.7443355087,
+          "documents": 173710,
+          "gap_bpb": -0.3249678412276267,
+          "model_a_bpb": 1.1049683543090894,
+          "model_b_bpb": 1.429936195536716,
+          "name": "text/number"
+        },
+        {
+          "bytes": 993004,
+          "delta_bits": -347847.5534832047,
+          "documents": 799744,
+          "gap_bpb": -0.35029823997003506,
+          "model_a_bpb": 0.9848580168989958,
+          "model_b_bpb": 1.3351562568690307,
+          "name": "text/punctuation"
+        },
+        {
+          "bytes": 97492,
+          "delta_bits": -3801.0299391572835,
+          "documents": 1923,
+          "gap_bpb": -0.038988121478247276,
+          "model_a_bpb": 0.9958693352854006,
+          "model_b_bpb": 1.034857456763648,
+          "name": "text/url"
+        },
+        {
+          "bytes": 17035730,
+          "delta_bits": 854198.2777988199,
+          "documents": 3430328,
+          "gap_bpb": 0.05014157173181425,
+          "model_a_bpb": 0.9359224370328552,
+          "model_b_bpb": 0.8857808653010409,
+          "name": "text/word"
+        },
+        {
+          "bytes": 377098,
+          "delta_bits": 50259.10651843118,
+          "documents": 47781,
+          "gap_bpb": 0.13327863451524852,
+          "model_a_bpb": 0.4883712170384906,
+          "model_b_bpb": 0.3550925825232422,
+          "name": "whitespace/mixed"
+        },
+        {
+          "bytes": 35659,
+          "delta_bits": -16328.866850797238,
+          "documents": 13755,
+          "gap_bpb": -0.457917127535748,
+          "model_a_bpb": 1.2263372082419326,
+          "model_b_bpb": 1.6842543357776805,
+          "name": "whitespace/multi_newline"
+        },
+        {
+          "bytes": 30687,
+          "delta_bits": 2859.4375930443725,
+          "documents": 5586,
+          "gap_bpb": 0.0931807473211579,
+          "model_a_bpb": 0.9067525546530567,
+          "model_b_bpb": 0.8135718073318988,
+          "name": "whitespace/multi_space"
+        },
+        {
+          "bytes": 81421,
+          "delta_bits": -24691.160017233287,
+          "documents": 81421,
+          "gap_bpb": -0.3032529693473832,
+          "model_a_bpb": 1.2479974520227342,
+          "model_b_bpb": 1.5512504213701175,
+          "name": "whitespace/newline"
+        },
+        {
+          "bytes": 3424589,
+          "delta_bits": -99007.16349776574,
+          "documents": 3424589,
+          "gap_bpb": -0.028910670301681672,
+          "model_a_bpb": 1.0098793407309834,
+          "model_b_bpb": 1.038790011032665,
+          "name": "whitespace/single_space"
+        },
+        {
+          "bytes": 97401,
+          "delta_bits": 1696.1071586415005,
+          "documents": 20609,
+          "gap_bpb": 0.017413652412618972,
+          "model_a_bpb": 0.6521326472858734,
+          "model_b_bpb": 0.6347189948732544,
+          "name": "whitespace/tab_or_cr"
+        }
+      ],
+      "ties": 0,
+      "top_literals": {
+        "model_a_worse": [
+          {
+            "bucket": "text/word",
+            "bytes": 516924,
+            "delta_bits": 216434.77241579234,
+            "documents": 172308,
+            "example_dataset": "paloma/redpajama",
+            "example_doc_preview": "\u2026&\u24200\u2420\\cr\u2420}\u2420{\\bf\u2420F}^*.\u21b5\u23ce\\end{equation}\u21b5\u23cewhere\u2420$\\sigma_x$\u2420is\u2420the\u2420Pauli\u2420spin\u2420matrix\u2420and\u2420$\\psi$\u2420is\u2420an\u2420arbitrary\u2420phase\u2420facto\u2026",
+            "gap_bpb": 0.4186974727731588,
+            "model_a_bpb": 0.8859704791753374,
+            "model_a_token_boundaries": "|\u2026th|e\u2026|",
+            "model_b_bpb": 0.46727300640217867,
+            "model_b_token_boundaries": "|\u2026the|",
+            "name": "the"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 190020,
+            "delta_bits": 81936.29261957084,
+            "documents": 95010,
+            "example_dataset": "uncheatable_eval/arxiv_physics",
+            "example_doc_preview": "\u2026icant\u2420progress\u2420has\u2420been\u2420made\u2420recently,\u2420with\u2420the\u2420discovery\u2420of\u2420theX(2370)as\u2420a\u2420pseudoscalar\u2420glueball\u2420candidate,\u2420or\u2420withpp\u2026",
+            "gap_bpb": 0.43119825607604906,
+            "model_a_bpb": 0.8701462172225921,
+            "model_a_token_boundaries": "|o|f|",
+            "model_b_bpb": 0.43894796114654305,
+            "model_b_token_boundaries": "|\u2026of|",
+            "name": "of"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 251766,
+            "delta_bits": 57674.148323996014,
+            "documents": 83922,
+            "example_dataset": "paloma/manosphere_meta_sep",
+            "example_doc_preview": "\u2026but\u2420when\u2420I\u2420gained\u242010\u2420lbs\u2420again\u2420I\u2420still\u2420got\u2420some\u2420PRs.\u2420\u21b5\u2420Oh\u2420and\u2420\u21b5\u2420>6'2\"\u2420\u21b5\u2420>Incel\u2420\u21b5\u2420Choose\u2420one.\u2420\u23ce\u23ce\u23ceLefterio13:\u23ce\u2420Copimg\u2420gy\u2026",
+            "gap_bpb": 0.2290783835942741,
+            "model_a_bpb": 0.9846893709731088,
+            "model_a_token_boundaries": "|a|nd|",
+            "model_b_bpb": 0.7556109873788347,
+            "model_b_token_boundaries": "|\u2026and|",
+            "name": "and"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 151080,
+            "delta_bits": 57567.316089408065,
+            "documents": 75540,
+            "example_dataset": "paloma/m2d2_s2orc_unsplit",
+            "example_doc_preview": "\u2026all\u2420artefact\u2420mounted\u2420in\u2420the\u2420tool\u2420holder\u2420and\u2420linear\u2420probes\u2420to\u2420*\u2420Corresponding\u2420author.\u23ceTel.:+33\u24201\u242047\u242040\u242027\u242057;\u2420Fax:+33\u24201\u2026",
+            "gap_bpb": 0.3810386291329631,
+            "model_a_bpb": 0.9346638793914549,
+            "model_a_token_boundaries": "|to|",
+            "model_b_bpb": 0.5536252502584917,
+            "model_b_token_boundaries": "|\u2026to|",
+            "name": "to"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 51012,
+            "delta_bits": 44382.09989802091,
+            "documents": 5668,
+            "example_dataset": "paloma/4chan",
+            "example_doc_preview": "\u2026bucket.\u23cehttps://www.youtube.com/watch?v=ipg\u23ce4EL_JUyE\u23ce\u23ce\u23ceAnonymous\u242010/15/19(Tue)16:27:38\u2420no.230263533:\u23ce>>230263530\u23cewhat\u2420\u2026",
+            "gap_bpb": 0.870032539363697,
+            "model_a_bpb": 0.9270272969564423,
+            "model_a_token_boundaries": "|An|on|y|mo|u|s|",
+            "model_b_bpb": 0.056994757592745304,
+            "model_b_token_boundaries": "|Anonymous|",
+            "name": "Anonymous"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 118876,
+            "delta_bits": 42155.742218172454,
+            "documents": 29719,
+            "example_dataset": "uncheatable_eval/arxiv_computer_science",
+            "example_doc_preview": "\u2026\u2420contrast,\u2420we\u2420assume\u2420each\u2420robot\u2420to\u2420be\u2420equipped\u2420withKLEDs\u2420that\u2420can\u2420be\u2420independently\u2420turned\u2420on\u2420and\u2420off,\u2420and\u2420to\u2420know\u2420the\u2420\u2026",
+            "gap_bpb": 0.3546194540375892,
+            "model_a_bpb": 0.9231041179441032,
+            "model_a_token_boundaries": "|t|h|a|t\u2026|",
+            "model_b_bpb": 0.5684846639065141,
+            "model_b_token_boundaries": "|\u2026that|",
+            "name": "that"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 100284,
+            "delta_bits": 24587.13790218831,
+            "documents": 25071,
+            "example_dataset": "paloma/4chan",
+            "example_doc_preview": "\u2026e\u2420you\u2420joined\u2420the\u2420discord\u2420yet?\u2420we'd\u2420love\u2420to\u2420have\u2420you\u2420help\u2420with\u2420thte\u2420media\u2420channels:\u2420cTbJxZ\u23ce\u23ce\u23ceAnonymous\u242011/06/17(Mon)14:\u2026",
+            "gap_bpb": 0.24517508178960065,
+            "model_a_bpb": 0.9349496823395538,
+            "model_a_token_boundaries": "|w|it|h|",
+            "model_b_bpb": 0.6897746005499532,
+            "model_b_token_boundaries": "|\u2026with|",
+            "name": "with"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 84862,
+            "delta_bits": 20741.635892933744,
+            "documents": 42431,
+            "example_dataset": "paloma/m2d2_s2orc_unsplit",
+            "example_doc_preview": "\u2026f\u2420Note\u2420that\u2420the\u2420Weber\u2420function\u2420is\u2420model\u2420independent.\u2420That\u2420is,\u2420if\u2420\u03d5\u2420:\u2420E\u2420\u2192\u2420E\u2420\u2032\u2420is\u2420anF\u2420-isomorphism\u2420and\u2420h\u2420E\u2420,\u2420h\u2420E\u2420\u2032\u2420the\u2420W\u2026",
+            "gap_bpb": 0.24441606246534073,
+            "model_a_bpb": 0.965713076552503,
+            "model_a_token_boundaries": "|i|s\u2026|",
+            "model_b_bpb": 0.7212970140871624,
+            "model_b_token_boundaries": "|\u2026is|",
+            "name": "is"
+          },
+          {
+            "bucket": "whitespace/mixed",
+            "bytes": 78705,
+            "delta_bits": 17987.9315223191,
+            "documents": 8745,
+            "example_dataset": "uncheatable_eval/github_python",
+            "example_doc_preview": "\u2026_ADDRESS\u2420=\u2420\"0x81b33972f8bdf14fD7968aC99CAc59BcaB7f4E9A\"\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420self.ERC20_CONTRACT_ABI\u2420=\u2420json.loads('''[\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2026",
+            "gap_bpb": 0.22854877736254495,
+            "model_a_bpb": 0.37885594676758866,
+            "model_a_token_boundaries": "|\u2026\u23ce|\u2420|\u2420|\u2420\u2420|\u2420\u2420|\u2420\u2420|",
+            "model_b_bpb": 0.1503071694050437,
+            "model_b_token_boundaries": "|\u2026\u23ce|\u2420\u2420\u2420\u2420\u2420\u2420\u2420|\u2420\u2026|",
+            "name": "\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 52833,
+            "delta_bits": 15139.647010110923,
+            "documents": 17611,
+            "example_dataset": "paloma/m2d2_wikipedia_unsplit",
+            "example_doc_preview": "\u2026es\u2420and\u2420operating\u2420utilities,\u2420and\u2420optical\u2420particle\u2420counters\u2420are\u2420also\u2420implemented.\u23ce\u23ce\u23ce755\u2420Quintilla\u23ce\u23ce755\u2420Quintilla\u2420(\"prov.\u2026",
+            "gap_bpb": 0.28655664092727884,
+            "model_a_bpb": 0.8939246312297398,
+            "model_a_token_boundaries": "|ar|e|",
+            "model_b_bpb": 0.6073679903024609,
+            "model_b_token_boundaries": "|\u2026are|",
+            "name": "are"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 39777,
+            "delta_bits": 14624.900180147175,
+            "documents": 13259,
+            "example_dataset": "paloma/manosphere_meta_sep",
+            "example_doc_preview": "\u2026e,\u2420no\u2420doubt\u2420about\u2420that,\u2420but\u2420not\u2420hideous\u2420(depending\u2420on\u2420who\u2420you\u2420ask).\u2420\u21b5\u2420Nah,\u2420I\u2420don't\u2420hit\u2420the\u2420gym\u2420so\u2420I'm\u2420all\u2420fat,\u2420but\u2420I\u2420h\u2026",
+            "gap_bpb": 0.3676722774504657,
+            "model_a_bpb": 0.9563599016954863,
+            "model_a_token_boundaries": "|y|ou\u2026|",
+            "model_b_bpb": 0.5886876242450207,
+            "model_b_token_boundaries": "|\u2026you|",
+            "name": "you"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 51702,
+            "delta_bits": 13984.89548150143,
+            "documents": 17234,
+            "example_dataset": "paloma/wikitext_103",
+            "example_doc_preview": "\u2026\u2420\"\u2420,\u2420which\u2420he\u2420recorded\u2420with\u2420Richards\u2420and\u2420Ronnie\u2420Wood\u2420.\u2420It\u2420was\u2420re\u2420@-@\u2420recorded\u2420by\u2420U2\u2420for\u2420the\u2420\"\u2420Where\u2420the\u2420Streets\u2420Have\u2420N\u2026",
+            "gap_bpb": 0.2704904158736882,
+            "model_a_bpb": 0.9302885791489152,
+            "model_a_token_boundaries": "|wa|s|",
+            "model_b_bpb": 0.659798163275227,
+            "model_b_token_boundaries": "|\u2026was|",
+            "name": "was"
+          }
+        ],
+        "model_b_worse": [
+          {
+            "bucket": "text/punctuation",
+            "bytes": 183488,
+            "delta_bits": -134248.37945080866,
+            "documents": 183488,
+            "example_dataset": "paloma/manosphere_meta_sep",
+            "example_doc_preview": "\u2026\u2420fat\u2420chick\u2420or\u2420trans?\"\u2420threads\u2420we've\u2420been\u2420having\u2420lol?\u2420\u21b5\u2420Yeah,\u2420I\u2420guess\u2420why\u2420not,\u2420but\u2420she\u2420isn't\u2420my\u2420type,\u2420even\u2420though\u2420she\u2420m\u2026",
+            "gap_bpb": -0.7316466441991228,
+            "model_a_bpb": 1.0864592833912354,
+            "model_a_token_boundaries": "|,|",
+            "model_b_bpb": 1.8181059275903582,
+            "model_b_token_boundaries": "|,|",
+            "name": ","
+          },
+          {
+            "bucket": "whitespace/single_space",
+            "bytes": 3424589,
+            "delta_bits": -99007.16349776574,
+            "documents": 3424589,
+            "example_dataset": "paloma/manosphere_meta_sep",
+            "example_doc_preview": "\u2026'.\u2420If\u2420girls\u2420don't\u2420like\u2420the\u2420look\u2420of\u2420you\u2420it's\u2420game\u2420over.\u21b5\u2420You\u2420have\u2420to\u2420looksmax.\u2420\u21b5\u2420Get\u2420a\u2420haircut\u21b5\u2420Train\u2420your\u2420neck\u21b5\u2420Get\u2420a\u2420\u2026",
+            "gap_bpb": -0.028910670301681672,
+            "model_a_bpb": 1.0098793407309834,
+            "model_a_token_boundaries": "|\u2420|",
+            "model_b_bpb": 1.038790011032665,
+            "model_b_token_boundaries": "|\u2420\u2026|",
+            "name": "\u2420"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 178473,
+            "delta_bits": -86356.32380875686,
+            "documents": 178473,
+            "example_dataset": "paloma/manosphere_meta_sep",
+            "example_doc_preview": "\u2026the\u2420charts.\u2420Look\u2420at\u2420that\u2420fucking\u2420ass\u2420and\u2420those\u2420fucking\u2420legs.\u2420\u21b5\u2420You\u2420may\u2420be\u2420into\u2420ultra\u2420thin\u2420girls,\u2420whatever,\u2420but\u2420please\u2420\u2026",
+            "gap_bpb": -0.4838621181285509,
+            "model_a_bpb": 1.1771953063338485,
+            "model_a_token_boundaries": "|.|",
+            "model_b_bpb": 1.661057424462399,
+            "model_b_token_boundaries": "|.|",
+            "name": "."
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 59323,
+            "delta_bits": -25261.973963430526,
+            "documents": 59323,
+            "example_dataset": "uncheatable_eval/arxiv_computer_science",
+            "example_doc_preview": "\u2026\u2420audio\u2420anti-deepfake\u2420system\u2420that\u2420utilize\u2420emotional\u2420features(EmoAnti)\u2420by\u2420exploiting\u2420a\u2420pretrained\u2420Wav2Vec2\u2420(W2V2)\u2420model\u2420\u2026",
+            "gap_bpb": -0.4258377688827356,
+            "model_a_bpb": 1.0231557925817871,
+            "model_a_token_boundaries": "|\u2026(|",
+            "model_b_bpb": 1.4489935614645226,
+            "model_b_token_boundaries": "|(|",
+            "name": "("
+          },
+          {
+            "bucket": "whitespace/newline",
+            "bytes": 81421,
+            "delta_bits": -24691.160017233287,
+            "documents": 81421,
+            "example_dataset": "paloma/4chan",
+            "example_doc_preview": "\u2026\u2420true.\u2420Source\u2420for\u2420that:\u23cewww.ecowatch.com/military-largest-p\u23ceolluter-2408760609.html\u23ce\u23ce\u23ceAnonymous\u242010/16/19(Wed)15:01:20\u2420\u2026",
+            "gap_bpb": -0.3032529693473832,
+            "model_a_bpb": 1.2479974520227342,
+            "model_a_token_boundaries": "|\u2026\u23ce\u2026|",
+            "model_b_bpb": 1.5512504213701175,
+            "model_b_token_boundaries": "|\u23ce|",
+            "name": "\u23ce"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 70450,
+            "delta_bits": -23842.139956667914,
+            "documents": 70450,
+            "example_dataset": "paloma/manosphere_meta_sep",
+            "example_doc_preview": "\u2026s\u2420reject\u2420me\u2420and\u2420treat\u2420me\u2420badly\u2420no\u2420matter\u2420what\u2420I\u2420do\u21b5\u2420I\u2420want\u2420a\u2420girlfriend\u2420so\u2420bad\u2420but\u2420I\u2420can't\u2420even\u2420get\u2420female\u2420friends\u2420\u21b5\u2420h\u2026",
+            "gap_bpb": -0.33842640108825994,
+            "model_a_bpb": 1.1032645356912179,
+            "model_a_token_boundaries": "|a|",
+            "model_b_bpb": 1.441690936779478,
+            "model_b_token_boundaries": "|\u2026a|",
+            "name": "a"
+          },
+          {
+            "bucket": "whitespace/multi_newline",
+            "bytes": 23724,
+            "delta_bits": -17621.5786748855,
+            "documents": 7908,
+            "example_dataset": "paloma/4chan",
+            "example_doc_preview": "\u202609/29/17(Fri)09:39:20\u2420no.143325753:\u23ce>>143323847\u23ceNice.\u2420Fpbp\u23ce\u23ce\u23ceAnonymous\u242009/29/17(Fri)09:40:21\u2420no.143325819:\u23ce>>143323742\u2026",
+            "gap_bpb": -0.7427743498097075,
+            "model_a_bpb": 1.3184022465797214,
+            "model_a_token_boundaries": "|\u23ce\u23ce|\u23ce\u2026|",
+            "model_b_bpb": 2.0611765963894286,
+            "model_b_token_boundaries": "|\u23ce\u23ce\u23ce|",
+            "name": "\u23ce\u23ce\u23ce"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 7617,
+            "delta_bits": -13399.034107266536,
+            "documents": 7617,
+            "example_dataset": "paloma/mc4",
+            "example_doc_preview": "\u2026r\u2420eye\u2420on\u2420the\u2420ball.\u2420That\u2420sometimes\u2420things\u2420don't\u2420always\u2420go\u2420my/our\u2420way\u2420and\u2420you\u2420learn\u2420to\u2420move\u2420past\u2420it\u2420or\u2420move\u2420away\u2420from\u2420it\u2026",
+            "gap_bpb": -1.7590959836243318,
+            "model_a_bpb": 1.3085118950835184,
+            "model_a_token_boundaries": "|\u2026/\u2026|",
+            "model_b_bpb": 3.0676078787078502,
+            "model_b_token_boundaries": "|/|",
+            "name": "/"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 23352,
+            "delta_bits": -12608.437721341626,
+            "documents": 11676,
+            "example_dataset": "paloma/m2d2_s2orc_unsplit",
+            "example_doc_preview": "\u2026ne\u242021.\u2420NullAway\u2420treats\u2420the\u2420init()\u2420method\u2420(lines\u242031\u015b34)\u2420as\u2420an\u2420initializer,\u2420due\u2420to\u2420the\u2420@Initializer\u2420annotation.\u2420For\u2420a\u2420me\u2026",
+            "gap_bpb": -0.5399296728906143,
+            "model_a_bpb": 1.0841990923013922,
+            "model_a_token_boundaries": "|a|n\u2026|",
+            "model_b_bpb": 1.6241287651920067,
+            "model_b_token_boundaries": "|\u2026an|",
+            "name": "an"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 13198,
+            "delta_bits": -12418.220291528838,
+            "documents": 13198,
+            "example_dataset": "paloma/manosphere_meta_sep",
+            "example_doc_preview": "\u2026other\u2420agenda\u2420other\u2420than\u2420meeting\u2420people.\u2420i\u2420think\u2420its\u2420because;\u2420you\u2420try\u2420and\u2420mack\u2420the\u2420target\u2420you\u2420dont\u2420show\u2420direct\u2420interest\u2026",
+            "gap_bpb": -0.9409168276654674,
+            "model_a_bpb": 0.8492973787890923,
+            "model_a_token_boundaries": "|\u2026;\u2026|",
+            "model_b_bpb": 1.7902142064545596,
+            "model_b_token_boundaries": "|;|",
+            "name": ";"
+          },
+          {
+            "bucket": "whitespace/mixed",
+            "bytes": 5268,
+            "delta_bits": -10887.254589973189,
+            "documents": 2634,
+            "example_dataset": "paloma/m2d2_s2orc_unsplit",
+            "example_doc_preview": "\u2026g(l).\u2420The\u2420ordered\u2420signal\u2420list\u2420OSL\u2420(dotted\u2420line\u2420in\u2420Figure\u24204\u2420\u23ceWhen\u2420an\u2420AOC\u2420model\u2420should\u2420be\u2420executed\u2420on\u2420a\u2420multithreaded\u2420pr\u2026",
+            "gap_bpb": -2.066677029228016,
+            "model_a_bpb": 1.6694658050906692,
+            "model_a_token_boundaries": "|\u2026\u2420|\u23ce\u2026|",
+            "model_b_bpb": 3.7361428343186853,
+            "model_b_token_boundaries": "|\u2420\u23ce|",
+            "name": "\u2420\u23ce"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 7221,
+            "delta_bits": -10222.480563069388,
+            "documents": 7221,
+            "example_dataset": "paloma/c4_en",
+            "example_doc_preview": "\u2026Rockets\u2420play\u2420host\u2420to\u2420No.\u24209\u2420Orange.\u2420The\u2420reward\u2420for\u2420winning?\u2420A\u2420March\u24201\u2420date\u2420with\u2420Hunter\u2420Drenth\u2420and\u2420the\u2420Revere\u2420Minutemen.\u2026",
+            "gap_bpb": -1.4156599588795717,
+            "model_a_bpb": 1.2435194765763016,
+            "model_a_token_boundaries": "|A|",
+            "model_b_bpb": 2.659179435455873,
+            "model_b_token_boundaries": "|\u2026A|",
+            "name": "A"
+          }
+        ]
+      },
+      "top_segments": {
+        "model_a_worse": [
+          {
+            "bucket": "text/url",
+            "bytes": 883,
+            "dataset": "paloma/mc4",
+            "delta_bits": 216.46766289107256,
+            "doc_preview": "\u2026wjgkx.jpg?imgeng=/w_300','https://images.webfronts.com/cache/frdxpcrskmne.jpg?imgeng=/w_300','https://images.webfronts\u2026",
+            "gap_bpb": 0.24515024109974243,
+            "text": "https://images.webfronts.com/ca\u2026"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 71,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": 152.3716774448345,
+            "doc_preview": "\u2026\u21e5\u21e5}\u23ce\u21e5}\u23ce\u21e5return\u2420(0);\u23ce}\u23ce\u23ce\u23ce/*====================================================================*\u23ce\u2420*\u23ce\u2420*\u2420\u2420\u2420signed\u2420CommitV\u2026",
+            "gap_bpb": 2.1460799640117534,
+            "text": "/*=============================\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 72,
+            "dataset": "paloma/mc4",
+            "delta_bits": 128.14355127759006,
+            "doc_preview": "\u2026cal(\"Roboto-Thin\"),url(https://fonts.gstatic.com/s/roboto/v20/KFOkCnqEu92Fr1MmgVxGIzIFKw.woff2)\u2420format(\"woff2\");unicod\u2026",
+            "gap_bpb": 1.7797715455220842,
+            "text": "https://fonts.gstatic.com/s/rob\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 35,
+            "dataset": "paloma/4chan",
+            "delta_bits": 123.8154209925811,
+            "doc_preview": "\u202614:22:29\u2420no.135428445:\u23ceThis\u2420is\u2420Iceland's:\u23cehttps://www.youtube.com/watch?v=9Fk\u23cebXTDzKBc\u23ce[624,092]\u23ce\u23ce\u23ceAnonymous\u242007/29/17(\u2026",
+            "gap_bpb": 3.5375834569308884,
+            "text": "https://www.youtube.com/watch?v\u2026"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 28,
+            "dataset": "paloma/mc4",
+            "delta_bits": 114.82185669624695,
+            "doc_preview": "\u2026:\u2420true,\u2420shipping_restriction_distance:\u2420'-1',\u2420item_in_stock_alerts_enabled:\u2420false,\u2420in_stock:\u2420false,\u2420in_stock_remaining:\u2026",
+            "gap_bpb": 4.100780596294534,
+            "text": "item_in_stock_alerts_enabled"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 45,
+            "dataset": "uncheatable_eval/github_cpp",
+            "delta_bits": 107.32655114846574,
+            "doc_preview": "\u2026TOR\u2420v2.4\u2420-\u2420CLEAN\u2420ARCH\");\u23ce\u2420\u2420LOG_LEGACY(\"========================================\");\u23ce\u2420\u2420\u23ce\u2420\u2420//\u24201.\u2420Load\u2420configuration\u23ce\u2420\u2420Ser\u2026",
+            "gap_bpb": 2.3850344699659054,
+            "text": "(\"=============================\u2026"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 17,
+            "dataset": "paloma/mc4",
+            "delta_bits": 103.24014791359532,
+            "doc_preview": "\u2026=\u2420this.findItem(item_key);\u2420sessionStorage.setItem('wishlist_item_add',\u2420item_key);\u2420$('#sign_in_modal').modal();\u2420},\u2420prod\u2026",
+            "gap_bpb": 6.072949877270313,
+            "text": "wishlist_item_add"
+          },
+          {
+            "bucket": "whitespace/multi_space",
+            "bytes": 45,
+            "dataset": "paloma/dolma-v1_5",
+            "delta_bits": 97.93305880688366,
+            "doc_preview": "\u2026\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u242013\u23ce\u2420\u2420Absolutism\u2420of\u2420the\u2420Crown\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u242014\u23ce\u2420\u2420Partial\u2420Checks\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2026",
+            "gap_bpb": 2.1762901957085257,
+            "text": "\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 43,
+            "dataset": "paloma/dolma_100_programing_languages",
+            "delta_bits": 95.84378722427667,
+            "doc_preview": "\u2026r-rubygem/AutoNic)\u23ce-\u2420[a-panzer\u24201.0.0](https://github.com/docker-rubygem/a-panzer)\u23ce-\u2420[a1408nw_Ounennhei\u24202.1.3](https://\u2026",
+            "gap_bpb": 2.228925284285504,
+            "text": "https://github.com/docker-rubyg\u2026"
+          },
+          {
+            "bucket": "text/word",
+            "bytes": 21,
+            "dataset": "paloma/4chan",
+            "delta_bits": 95.04643537039603,
+            "doc_preview": "\u2026r/IAmA/comme\u23cents/ai2det/were_the_krassenstein_br\u23ceothers_we_uncovered_a/\u23ce\u23ce\u23ceAnonymous\u242001/22/19(Tue)16:12:00\u2420no.200689082\u2026",
+            "gap_bpb": 4.52602073192362,
+            "text": "others_we_uncovered_a"
+          },
+          {
+            "bucket": "text/punctuation",
+            "bytes": 60,
+            "dataset": "paloma/mc4",
+            "delta_bits": 87.0656975968131,
+            "doc_preview": "\u2026e\u2420success\u23ce08:49:58.0360\u24204588\u21e5============================================================\u23ce08:49:58.0360\u24204588\u21e5Scan\u2420star\u2026",
+            "gap_bpb": 1.451094959946885,
+            "text": "===============================\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 35,
+            "dataset": "paloma/4chan",
+            "delta_bits": 84.66569581648056,
+            "doc_preview": "\u202642\u2420no.135431349:\u23ceHere's\u2420the\u2420full\u2420version:\u23cehttps://www.youtube.com/watch?v=nVO\u23cefzB7Gn3Y\u23ce[56,748]\u23ceHail\u2420O'Duffy\u2420of\u2420the\u2420Bl\u2026",
+            "gap_bpb": 2.419019880470873,
+            "text": "https://www.youtube.com/watch?v\u2026"
+          }
+        ],
+        "model_b_worse": [
+          {
+            "bucket": "text/url",
+            "bytes": 89,
+            "dataset": "paloma/mc4",
+            "delta_bits": -268.30777478305134,
+            "doc_preview": "\u2026to-Black\"),url(https://fonts.gstatic.com/s/roboto/v16/mnpfi9pxYH-Go5UiibESIpBw1xU1rKptJj_0jans920.woff2)\u2420format(\"woff2\u2026",
+            "gap_bpb": -3.01469409868597,
+            "text": "https://fonts.gstatic.com/s/rob\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 89,
+            "dataset": "paloma/mc4",
+            "delta_bits": -234.41196584256838,
+            "doc_preview": "\u2026to-Black\"),url(https://fonts.gstatic.com/s/roboto/v16/s7gftie1JANC-QmDJvMWZoX0hVgzZQUfRDuZrPvH3D8.woff2)\u2420format(\"woff2\u2026",
+            "gap_bpb": -2.6338423128378468,
+            "text": "https://fonts.gstatic.com/s/rob\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 67,
+            "dataset": "paloma/mc4",
+            "delta_bits": -200.37893724602753,
+            "doc_preview": "\u2026ions:\u2420[\u2420],\u2420image_urls:\u2420[\u2420'https://images.webfronts.com/cache/frskfdklvcqv.jpg?imgeng=/w_300',\u2420'https://images.webfront\u2026",
+            "gap_bpb": -2.990730406657127,
+            "text": "https://images.webfronts.com/ca\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 89,
+            "dataset": "paloma/mc4",
+            "delta_bits": -185.04138822464807,
+            "doc_preview": "\u2026to-Black\"),url(https://fonts.gstatic.com/s/roboto/v16/3Y_xCyt7TNunMGg0Et2pnoX0hVgzZQUfRDuZrPvH3D8.woff2)\u2420format(\"woff2\u2026",
+            "gap_bpb": -2.079116721625259,
+            "text": "https://fonts.gstatic.com/s/rob\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 67,
+            "dataset": "paloma/mc4",
+            "delta_bits": -144.63580649015708,
+            "doc_preview": "\u2026ions:\u2420[\u2420],\u2420image_urls:\u2420[\u2420'https://images.webfronts.com/cache/frhtxpvaylak.jpg?imgeng=/w_300',\u2420'https://images.webfront\u2026",
+            "gap_bpb": -2.1587433804501055,
+            "text": "https://images.webfronts.com/ca\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 72,
+            "dataset": "paloma/mc4",
+            "delta_bits": -137.68184147840316,
+            "doc_preview": "\u2026cal(\"Roboto-Thin\"),url(https://fonts.gstatic.com/s/roboto/v20/KFOkCnqEu92Fr1MmgVxMIzIFKw.woff2)\u2420format(\"woff2\");unicod\u2026",
+            "gap_bpb": -1.912247798311155,
+            "text": "https://fonts.gstatic.com/s/rob\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 89,
+            "dataset": "paloma/mc4",
+            "delta_bits": -132.8123896896157,
+            "doc_preview": "\u2026to-Black\"),url(https://fonts.gstatic.com/s/roboto/v16/WeQRRE07FDkIrr29oHQgHIX0hVgzZQUfRDuZrPvH3D8.woff2)\u2420format(\"woff2\u2026",
+            "gap_bpb": -1.4922740414563562,
+            "text": "https://fonts.gstatic.com/s/rob\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 89,
+            "dataset": "paloma/mc4",
+            "delta_bits": -120.64703976258822,
+            "doc_preview": "\u2026to-Black\"),url(https://fonts.gstatic.com/s/roboto/v16/9_7S_tWeGDh5Pq3u05RVkoX0hVgzZQUfRDuZrPvH3D8.woff2)\u2420format(\"woff2\u2026",
+            "gap_bpb": -1.3555847164335755,
+            "text": "https://fonts.gstatic.com/s/rob\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 89,
+            "dataset": "paloma/mc4",
+            "delta_bits": -120.43621445967332,
+            "doc_preview": "\u2026to-Black\"),url(https://fonts.gstatic.com/s/roboto/v16/jyIYROCkJM3gZ4KV00YXOIX0hVgzZQUfRDuZrPvH3D8.woff2)\u2420format(\"woff2\u2026",
+            "gap_bpb": -1.3532158928053182,
+            "text": "https://fonts.gstatic.com/s/rob\u2026"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 135,
+            "dataset": "paloma/mc4",
+            "delta_bits": -116.96973469960339,
+            "doc_preview": "\u2026images.webfronts.com/cache/frpccopatfdq.jpg?imgeng=/w_300','https://images.webfronts.com/cache/frrxvbnhshef.jpg?imgeng\u2026",
+            "gap_bpb": -0.8664424792563215,
+            "text": "https://images.webfronts.com/ca\u2026"
+          },
+          {
+            "bucket": "text/non_ascii_word",
+            "bytes": 57,
+            "dataset": "uncheatable_eval/github_cpp",
+            "delta_bits": -115.67693425739002,
+            "doc_preview": "\u2026\u2420\"\\nRandom\u2420\uc544\uc774\ud15c\uc744\u2420\uad6c\ub9e4\ud569\ub2c8\ub2e4!\\n\";\u21b5\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420std::cout\u2420<<\u2420\"\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\\n\";\u21b5\u23ce\u21b5\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420switch\u2420(random)\u21b5\u23ce\u2420\u2420\u2420\u2420\u2420\u2420\u2420\u2420{\u21b5\u23ce\u2420\u2420\u2420\u2420\u2420\u2026",
+            "gap_bpb": -2.0294198992524564,
+            "text": "\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137\u3131\u3137"
+          },
+          {
+            "bucket": "text/url",
+            "bytes": 89,
+            "dataset": "paloma/mc4",
+            "delta_bits": -110.64365310158894,
+            "doc_preview": "\u2026to-Black\"),url(https://fonts.gstatic.com/s/roboto/v16/phsu-QZXz1JBv0PbFoPmEIX0hVgzZQUfRDuZrPvH3D8.woff2)\u2420format(\"woff2\u2026",
+            "gap_bpb": -1.2431871135009993,
+            "text": "https://fonts.gstatic.com/s/rob\u2026"
+          }
+        ]
+      },
+      "uncheatable_gap_bpb": 0.006996561511227297,
+      "wins": 7
+    }
+  ],
+  "generated_at": "2026-05-28",
+  "models": {
+    "gemma3-262k": "Gemma 3 tokenizer, 262k vocab",
+    "gpt-oss-200k": "GPT-OSS tokenizer, 200k vocab",
+    "llama3-128k": "Llama 3 tokenizer, 128k vocab",
+    "qwen3-152k": "Qwen3 tokenizer, 152k vocab",
+    "tokenmonster-englishcode-32k": "TokenMonster English/code, 32k vocab"
+  },
+  "notes": [
+    "Gap is candidate BPB minus llama3-128k BPB; negative means the candidate tokenizer/model path is better on that slice.",
+    "These are d_model=1024 patched perplexity-gap runs. The TokenMonster accounting is byte-offset corrected; earlier W&B readouts where TokenMonster looked best are superseded.",
+    "This is not a pure intrinsic-tokenizer ranking: larger vocabularies imply larger embedding/LM-head parameter counts at fixed d_model, and token budgets differ from raw byte budgets."
+  ],
+  "score_prefix": "gs://marin-eu-west4/analysis/model_perplexity_scores/tokenizer-sensitivity-d1024/",
+  "scores": [
+    {
+      "bytes": 23108960,
+      "dataset_groups": [
+        {
+          "bits": 15648588.640930718,
+          "bpb": 0.9776687588747509,
+          "bytes": 16006023,
+          "documents": 3348,
+          "name": "paloma"
+        },
+        {
+          "bits": 6046244.21136307,
+          "bpb": 0.8512315696117071,
+          "bytes": 7102937,
+          "documents": 1792,
+          "name": "uncheatable_eval"
+        }
+      ],
+      "datasets": [
+        {
+          "bits": 1225160.4386409037,
+          "bpb": 1.1477514873294559,
+          "bytes": 1067444,
+          "documents": 256,
+          "name": "paloma/4chan"
+        },
+        {
+          "bits": 744042.291432928,
+          "bpb": 0.9995167818368677,
+          "bytes": 744402,
+          "documents": 256,
+          "name": "paloma/c4_100_domains"
+        },
+        {
+          "bits": 510341.8096654147,
+          "bpb": 0.9751015235127045,
+          "bytes": 523373,
+          "documents": 256,
+          "name": "paloma/c4_en"
+        },
+        {
+          "bits": 883906.0994695617,
+          "bpb": 1.0292039699235138,
+          "bytes": 858825,
+          "documents": 256,
+          "name": "paloma/dolma-v1_5"
+        },
+        {
+          "bits": 585853.6313997819,
+          "bpb": 0.6520751202352753,
+          "bytes": 898445,
+          "documents": 256,
+          "name": "paloma/dolma_100_programing_languages"
+        },
+        {
+          "bits": 229554.4492368927,
+          "bpb": 1.1252393286286742,
+          "bytes": 204005,
+          "documents": 256,
+          "name": "paloma/dolma_100_subreddits"
+        },
+        {
+          "bits": 722419.8338017046,
+          "bpb": 1.03084580659858,
+          "bytes": 700803,
+          "documents": 256,
+          "name": "paloma/falcon-refinedweb"
+        },
+        {
+          "bits": 62004.36409302901,
+          "bpb": 1.649096095455438,
+          "bytes": 37599,
+          "documents": 256,
+          "name": "paloma/gab"
+        },
+        {
+          "bits": 5182823.061057228,
+          "bpb": 0.9471095472115831,
+          "bytes": 5472253,
+          "documents": 167,
+          "name": "paloma/m2d2_s2orc_unsplit"
+        },
+        {
+          "bits": 1530023.9696936365,
+          "bpb": 0.9529107352703711,
+          "bytes": 1605632,
+          "documents": 49,
+          "name": "paloma/m2d2_wikipedia_unsplit"
+        },
+        {
+          "bits": 1165657.1588841479,
+          "bpb": 1.1651025700607989,
+          "bytes": 1000476,
+          "documents": 256,
+          "name": "paloma/manosphere_meta_sep"
+        },
+        {
+          "bits": 943091.6079833792,
+          "bpb": 0.9674530430606904,
+          "bytes": 974819,
+          "documents": 256,
+          "name": "paloma/mc4"
+        },
+        {
+          "bits": 39566.1056110588,
+          "bpb": 1.207461719087488,
+          "bytes": 32768,
+          "documents": 1,
+          "name": "paloma/ptb"
+        },
+        {
+          "bits": 849702.4251963153,
+          "bpb": 0.957047774756307,
+          "bytes": 887837,
+          "documents": 256,
+          "name": "paloma/redpajama"
+        },
+        {
+          "bits": 26362.57594303769,
+          "bpb": 2.7321562797220116,
+          "bytes": 9649,
+          "documents": 256,
+          "name": "paloma/twitterAAE_HELM_fixed"
+        },
+        {
+          "bits": 948078.8188216961,
+          "bpb": 0.959892212278204,
+          "bytes": 987693,
+          "documents": 59,
+          "name": "paloma/wikitext_103"
+        },
+        {
+          "bits": 1362560.5835865915,
+          "bpb": 1.1140732333314185,
+          "bytes": 1223044,
+          "documents": 256,
+          "name": "uncheatable_eval/ao3_english"
+        },
+        {
+          "bits": 1038812.2168534937,
+          "bpb": 0.8392149997443071,
+          "bytes": 1237838,
+          "documents": 256,
+          "name": "uncheatable_eval/arxiv_computer_science"
+        },
+        {
+          "bits": 1152330.7715379123,
+          "bpb": 0.898780342903204,
+          "bytes": 1282105,
+          "documents": 256,
+          "name": "uncheatable_eval/arxiv_physics"
+        },
+        {
+          "bits": 774820.0719282884,
+          "bpb": 0.9210353556774373,
+          "bytes": 841249,
+          "documents": 256,
+          "name": "uncheatable_eval/bbc_news"
+        },
+        {
+          "bits": 539972.1571365186,
+          "bpb": 0.6159249412691202,
+          "bytes": 876685,
+          "documents": 256,
+          "name": "uncheatable_eval/github_cpp"
+        },
+        {
+          "bits": 567912.343542588,
+          "bpb": 0.5642952112385489,
+          "bytes": 1006410,
+          "documents": 256,
+          "name": "uncheatable_eval/github_python"
+        },
+        {
+          "bits": 609836.066777677,
+          "bpb": 0.9594561202658204,
+          "bytes": 635606,
+          "documents": 256,
+          "name": "uncheatable_eval/wikipedia_english"
+        }
+      ],
+      "documents": 5140,
+      "label": "Gemma 3 tokenizer, 262k vocab",
+      "model": "gemma3-262k",
+      "overall_bpb": 0.9388061103699077,
+      "paloma_bpb": 0.9776687588747509,
+      "pattern_buckets": [
+        {
+          "bits": 153374.68939533384,
+          "bpb": 1.3836237203007113,
+          "bytes": 110850,
+          "documents": 33576,
+          "name": "text/non_ascii"
+        },
+        {
+          "bits": 323391.4998440176,
+          "bpb": 1.3288441539758205,
+          "bytes": 243363,
+          "documents": 36486,
+          "name": "text/non_ascii_word"
+        },
+        {
+          "bits": 791127.5322733785,
+          "bpb": 1.3601061988725118,
+          "bytes": 581666,
+          "documents": 173710,
+          "name": "text/number"
+        },
+        {
+          "bits": 1263781.563751471,
+          "bpb": 1.2726852698996893,
+          "bytes": 993004,
+          "documents": 799744,
+          "name": "text/punctuation"
+        },
+        {
+          "bits": 97404.50354888848,
+          "bpb": 0.9991025268625987,
+          "bytes": 97492,
+          "documents": 1923,
+          "name": "text/url"
+        },
+        {
+          "bits": 15231692.562387688,
+          "bpb": 0.8941027218902676,
+          "bytes": 17035730,
+          "documents": 3430328,
+          "name": "text/word"
+        },
+        {
+          "bits": 99099.7910288984,
+          "bpb": 0.2627958542047383,
+          "bytes": 377098,
+          "documents": 47781,
+          "name": "whitespace/mixed"
+        },
+        {
+          "bits": 46730.96643245009,
+          "bpb": 1.3104957074637564,
+          "bytes": 35659,
+          "documents": 13755,
+          "name": "whitespace/multi_newline"
+        },
+        {
+          "bits": 22924.826628284125,
+          "bpb": 0.7470533655386361,
+          "bytes": 30687,
+          "documents": 5586,
+          "name": "whitespace/multi_space"
+        },
+        {
+          "bits": 128278.29356054509,
+          "bpb": 1.5754939580764802,
+          "bytes": 81421,
+          "documents": 81421,
+          "name": "whitespace/newline"
+        },
+        {
+          "bits": 3504904.2169572306,
+          "bpb": 1.023452512683195,
+          "bytes": 3424589,
+          "documents": 3424589,
+          "name": "whitespace/single_space"
+        },
+        {
+          "bits": 32122.406485636195,
+          "bpb": 0.3297954485645547,
+          "bytes": 97401,
+          "documents": 20609,
+          "name": "whitespace/tab_or_cr"
+        }
+      ],
+      "uncheatable_bpb": 0.8512315696117071
+    },
+    {
+      "bytes": 23108960,
+      "dataset_groups": [
+        {
+          "bits": 15643770.104381308,
+          "bpb": 0.977367713665119,
+          "bytes": 16006023,
+          "documents": 3348,
+          "name": "paloma"
+        },
+        {
+          "bits": 6058052.750806179,
+          "bpb": 0.8528940564735656,
+          "bytes": 7102937,
+          "documents": 1792,
+          "name": "uncheatable_eval"
+        }
+      ],
+      "datasets": [
+        {
+          "bits": 1235952.3097271763,
+          "bpb": 1.157861498801976,
+          "bytes": 1067444,
+          "documents": 256,
+          "name": "paloma/4chan"
+        },
+        {
+          "bits": 743243.3668124384,
+          "bpb": 0.9984435383199378,
+          "bytes": 744402,
+          "documents": 256,
+          "name": "paloma/c4_100_domains"
+        },
+        {
+          "bits": 511028.343362571,
+          "bpb": 0.9764132719161496,
+          "bytes": 523373,
+          "documents": 256,
+          "name": "paloma/c4_en"
+        },
+        {
+          "bits": 884371.3128925856,
+          "bpb": 1.0297456558583944,
+          "bytes": 858825,
+          "documents": 256,
+          "name": "paloma/dolma-v1_5"
+        },
+        {
+          "bits": 587496.9885251512,
+          "bpb": 0.6539042328970067,
+          "bytes": 898445,
+          "documents": 256,
+          "name": "paloma/dolma_100_programing_languages"
+        },
+        {
+          "bits": 231641.40190092887,
+          "bpb": 1.1354692380134255,
+          "bytes": 204005,
+          "documents": 256,
+          "name": "paloma/dolma_100_subreddits"
+        },
+        {
+          "bits": 721281.203478813,
+          "bpb": 1.0292210556730108,
+          "bytes": 700803,
+          "documents": 256,
+          "name": "paloma/falcon-refinedweb"
+        },
+        {
+          "bits": 65337.889263197,
+          "bpb": 1.737756037745605,
+          "bytes": 37599,
+          "documents": 256,
+          "name": "paloma/gab"
+        },
+        {
+          "bits": 5158507.021942544,
+          "bpb": 0.9426660320607515,
+          "bytes": 5472253,
+          "documents": 167,
+          "name": "paloma/m2d2_s2orc_unsplit"
+        },
+        {
+          "bits": 1527843.0571583407,
+          "bpb": 0.9515524461136429,
+          "bytes": 1605632,
+          "documents": 49,
+          "name": "paloma/m2d2_wikipedia_unsplit"
+        },
+        {
+          "bits": 1178815.1956847229,
+          "bpb": 1.1782543466157338,
+          "bytes": 1000476,
+          "documents": 256,
+          "name": "paloma/manosphere_meta_sep"
+        },
+        {
+          "bits": 939209.720398223,
+          "bpb": 0.9634708806437123,
+          "bytes": 974819,
+          "documents": 256,
+          "name": "paloma/mc4"
+        },
+        {
+          "bits": 37303.17575790735,
+          "bpb": 1.1384025805025437,
+          "bytes": 32768,
+          "documents": 1,
+          "name": "paloma/ptb"
+        },
+        {
+          "bits": 847596.0357365333,
+          "bpb": 0.9546752790619599,
+          "bytes": 887837,
+          "documents": 256,
+          "name": "paloma/redpajama"
+        },
+        {
+          "bits": 28566.58602235426,
+          "bpb": 2.960574776904784,
+          "bytes": 9649,
+          "documents": 256,
+          "name": "paloma/twitterAAE_HELM_fixed"
+        },
+        {
+          "bits": 945576.4957178212,
+          "bpb": 0.9573587093538388,
+          "bytes": 987693,
+          "documents": 59,
+          "name": "paloma/wikitext_103"
+        },
+        {
+          "bits": 1362563.5453392651,
+          "bpb": 1.1140756549553943,
+          "bytes": 1223044,
+          "documents": 256,
+          "name": "uncheatable_eval/ao3_english"
+        },
+        {
+          "bits": 1034607.7935033736,
+          "bpb": 0.8358184136400512,
+          "bytes": 1237838,
+          "documents": 256,
+          "name": "uncheatable_eval/arxiv_computer_science"
+        },
+        {
+          "bits": 1154404.9190588829,
+          "bpb": 0.9003981101851118,
+          "bytes": 1282105,
+          "documents": 256,
+          "name": "uncheatable_eval/arxiv_physics"
+        },
+        {
+          "bits": 775597.102063366,
+          "bpb": 0.9219590181543942,
+          "bytes": 841249,
+          "documents": 256,
+          "name": "uncheatable_eval/bbc_news"
+        },
+        {
+          "bits": 549151.9192938338,
+          "bpb": 0.6263959338802806,
+          "bytes": 876685,
+          "documents": 256,
+          "name": "uncheatable_eval/github_cpp"
+        },
+        {
+          "bits": 573022.3228783844,
+          "bpb": 0.5693726442288772,
+          "bytes": 1006410,
+          "documents": 256,
+          "name": "uncheatable_eval/github_python"
+        },
+        {
+          "bits": 608705.1486690735,
+          "bpb": 0.9576768448835812,
+          "bytes": 635606,
+          "documents": 256,
+          "name": "uncheatable_eval/wikipedia_english"
+        }
+      ],
+      "documents": 5140,
+      "label": "GPT-OSS tokenizer, 200k vocab",
+      "model": "gpt-oss-200k",
+      "overall_bpb": 0.9391085905721195,
+      "paloma_bpb": 0.977367713665119,
+      "pattern_buckets": [
+        {
+          "bits": 162194.87534690503,
+          "bpb": 1.4631923802156521,
+          "bytes": 110850,
+          "documents": 33576,
+          "name": "text/non_ascii"
+        },
+        {
+          "bits": 318097.1492616388,
+          "bpb": 1.3070892011589224,
+          "bytes": 243363,
+          "documents": 36486,
+          "name": "text/non_ascii_word"
+        },
+        {
+          "bits": 827251.3652952183,
+          "bpb": 1.4222102809777748,
+          "bytes": 581666,
+          "documents": 173710,
+          "name": "text/number"
+        },
+        {
+          "bits": 1327393.4580320753,
+          "bpb": 1.3367453283492063,
+          "bytes": 993004,
+          "documents": 799744,
+          "name": "text/punctuation"
+        },
+        {
+          "bits": 101083.77995239408,
+          "bpb": 1.036841791658742,
+          "bytes": 97492,
+          "documents": 1923,
+          "name": "text/url"
+        },
+        {
+          "bits": 15042031.667063974,
+          "bpb": 0.8829695978431199,
+          "bytes": 17035730,
+          "documents": 3430328,
+          "name": "text/word"
+        },
+        {
+          "bits": 128990.57913202756,
+          "bpb": 0.3420611595182885,
+          "bytes": 377098,
+          "documents": 47781,
+          "name": "whitespace/mixed"
+        },
+        {
+          "bits": 56358.69249778786,
+          "bpb": 1.5804899884401655,
+          "bytes": 35659,
+          "documents": 13755,
+          "name": "whitespace/multi_newline"
+        },
+        {
+          "bits": 25653.515579473293,
+          "bpb": 0.8359733952316386,
+          "bytes": 30687,
+          "documents": 5586,
+          "name": "whitespace/multi_space"
+        },
+        {
+          "bits": 127226.60302641355,
+          "bpb": 1.562577259262519,
+          "bytes": 81421,
+          "documents": 81421,
+          "name": "whitespace/newline"
+        },
+        {
+          "bits": 3524373.855801557,
+          "bpb": 1.0291377609989278,
+          "bytes": 3424589,
+          "documents": 3424589,
+          "name": "whitespace/single_space"
+        },
+        {
+          "bits": 61167.31419925675,
+          "bpb": 0.6279947248925242,
+          "bytes": 97401,
+          "documents": 20609,
+          "name": "whitespace/tab_or_cr"
+        }
+      ],
+      "uncheatable_bpb": 0.8528940564735656
+    },
+    {
+      "bytes": 23108960,
+      "dataset_groups": [
+        {
+          "bits": 15691023.493748643,
+          "bpb": 0.9803199391721881,
+          "bytes": 16006023,
+          "documents": 3348,
+          "name": "paloma"
+        },
+        {
+          "bits": 6097996.852035875,
+          "bpb": 0.8585176599533229,
+          "bytes": 7102937,
+          "documents": 1792,
+          "name": "uncheatable_eval"
+        }
+      ],
+      "datasets": [
+        {
+          "bits": 1242437.6826410054,
+          "bpb": 1.1639371083082628,
+          "bytes": 1067444,
+          "documents": 256,
+          "name": "paloma/4chan"
+        },
+        {
+          "bits": 745316.6762691302,
+          "bpb": 1.0012287396717503,
+          "bytes": 744402,
+          "documents": 256,
+          "name": "paloma/c4_100_domains"
+        },
+        {
+          "bits": 511837.91591563344,
+          "bpb": 0.9779601085948901,
+          "bytes": 523373,
+          "documents": 256,
+          "name": "paloma/c4_en"
+        },
+        {
+          "bits": 884989.0329785451,
+          "bpb": 1.03046491774057,
+          "bytes": 858825,
+          "documents": 256,
+          "name": "paloma/dolma-v1_5"
+        },
+        {
+          "bits": 593414.8679577471,
+          "bpb": 0.6604910350191131,
+          "bytes": 898445,
+          "documents": 256,
+          "name": "paloma/dolma_100_programing_languages"
+        },
+        {
+          "bits": 230518.51406419702,
+          "bpb": 1.1299650207798682,
+          "bytes": 204005,
+          "documents": 256,
+          "name": "paloma/dolma_100_subreddits"
+        },
+        {
+          "bits": 723128.5106676313,
+          "bpb": 1.0318570420897617,
+          "bytes": 700803,
+          "documents": 256,
+          "name": "paloma/falcon-refinedweb"
+        },
+        {
+          "bits": 62942.56898287027,
+          "bpb": 1.6740490168055073,
+          "bytes": 37599,
+          "documents": 256,
+          "name": "paloma/gab"
+        },
+        {
+          "bits": 5171540.259193914,
+          "bpb": 0.9450477269954284,
+          "bytes": 5472253,
+          "documents": 167,
+          "name": "paloma/m2d2_s2orc_unsplit"
+        },
+        {
+          "bits": 1533718.852208304,
+          "bpb": 0.9552119366133112,
+          "bytes": 1605632,
+          "documents": 49,
+          "name": "paloma/m2d2_wikipedia_unsplit"
+        },
+        {
+          "bits": 1180991.1717465038,
+          "bpb": 1.1804292874056987,
+          "bytes": 1000476,
+          "documents": 256,
+          "name": "paloma/manosphere_meta_sep"
+        },
+        {
+          "bits": 943857.4490474466,
+          "bpb": 0.9682386669191374,
+          "bytes": 974819,
+          "documents": 256,
+          "name": "paloma/mc4"
+        },
+        {
+          "bits": 37175.90966077696,
+          "bpb": 1.1345187274407031,
+          "bytes": 32768,
+          "documents": 1,
+          "name": "paloma/ptb"
+        },
+        {
+          "bits": 852377.9829905558,
+          "bpb": 0.9600613434566884,
+          "bytes": 887837,
+          "documents": 256,
+          "name": "paloma/redpajama"
+        },
+        {
+          "bits": 26473.303110817797,
+          "bpb": 2.7436317867984035,
+          "bytes": 9649,
+          "documents": 256,
+          "name": "paloma/twitterAAE_HELM_fixed"
+        },
+        {
+          "bits": 950302.7963135638,
+          "bpb": 0.9621439013069485,
+          "bytes": 987693,
+          "documents": 59,
+          "name": "paloma/wikitext_103"
+        },
+        {
+          "bits": 1363318.1791247479,
+          "bpb": 1.1146926677411015,
+          "bytes": 1223044,
+          "documents": 256,
+          "name": "uncheatable_eval/ao3_english"
+        },
+        {
+          "bits": 1041453.5794722099,
+          "bpb": 0.8413488513619795,
+          "bytes": 1237838,
+          "documents": 256,
+          "name": "uncheatable_eval/arxiv_computer_science"
+        },
+        {
+          "bits": 1159205.1938866759,
+          "bpb": 0.9041421676747816,
+          "bytes": 1282105,
+          "documents": 256,
+          "name": "uncheatable_eval/arxiv_physics"
+        },
+        {
+          "bits": 777396.786020696,
+          "bpb": 0.9240983181206707,
+          "bytes": 841249,
+          "documents": 256,
+          "name": "uncheatable_eval/bbc_news"
+        },
+        {
+          "bits": 560707.5926633773,
+          "bpb": 0.6395770346970432,
+          "bytes": 876685,
+          "documents": 256,
+          "name": "uncheatable_eval/github_cpp"
+        },
+        {
+          "bits": 586260.8662937346,
+          "bpb": 0.5825268690630405,
+          "bytes": 1006410,
+          "documents": 256,
+          "name": "uncheatable_eval/github_python"
+        },
+        {
+          "bits": 609654.6545744335,
+          "bpb": 0.9591707041381508,
+          "bytes": 635606,
+          "documents": 256,
+          "name": "uncheatable_eval/wikipedia_english"
+        }
+      ],
+      "documents": 5140,
+      "label": "Llama 3 tokenizer, 128k vocab",
+      "model": "llama3-128k",
+      "overall_bpb": 0.9428819101242338,
+      "paloma_bpb": 0.9803199391721881,
+      "pattern_buckets": [
+        {
+          "bits": 156804.1051075012,
+          "bpb": 1.4145611647045666,
+          "bytes": 110850,
+          "documents": 33576,
+          "name": "text/non_ascii"
+        },
+        {
+          "bits": 319356.409692948,
+          "bpb": 1.3122636131743444,
+          "bytes": 243363,
+          "documents": 36486,
+          "name": "text/non_ascii_word"
+        },
+        {
+          "bits": 831745.2671130594,
+          "bpb": 1.429936195536716,
+          "bytes": 581666,
+          "documents": 173710,
+          "name": "text/number"
+        },
+        {
+          "bits": 1325815.503695975,
+          "bpb": 1.3351562568690307,
+          "bytes": 993004,
+          "documents": 799744,
+          "name": "text/punctuation"
+        },
+        {
+          "bits": 100890.32317480166,
+          "bpb": 1.0348574567636488,
+          "bytes": 97492,
+          "documents": 1923,
+          "name": "text/url"
+        },
+        {
+          "bits": 15089923.66043458,
+          "bpb": 0.885780865301022,
+          "bytes": 17035730,
+          "documents": 3430328,
+          "name": "text/word"
+        },
+        {
+          "bits": 133904.70268434816,
+          "bpb": 0.3550925825232384,
+          "bytes": 377098,
+          "documents": 47781,
+          "name": "whitespace/mixed"
+        },
+        {
+          "bits": 60058.825359496324,
+          "bpb": 1.684254335777681,
+          "bytes": 35659,
+          "documents": 13755,
+          "name": "whitespace/multi_newline"
+        },
+        {
+          "bits": 24966.078051594068,
+          "bpb": 0.8135718073319017,
+          "bytes": 30687,
+          "documents": 5586,
+          "name": "whitespace/multi_space"
+        },
+        {
+          "bits": 126304.36055837633,
+          "bpb": 1.5512504213701175,
+          "bytes": 81421,
+          "documents": 81421,
+          "name": "whitespace/newline"
+        },
+        {
+          "bits": 3557428.845092201,
+          "bpb": 1.0387900110326236,
+          "bytes": 3424589,
+          "documents": 3424589,
+          "name": "whitespace/single_space"
+        },
+        {
+          "bits": 61822.264819649696,
+          "bpb": 0.6347189948732528,
+          "bytes": 97401,
+          "documents": 20609,
+          "name": "whitespace/tab_or_cr"
+        }
+      ],
+      "uncheatable_bpb": 0.8585176599533229
+    },
+    {
+      "bytes": 23108960,
+      "dataset_groups": [
+        {
+          "bits": 15684689.795797903,
+          "bpb": 0.9799242320092819,
+          "bytes": 16006023,
+          "documents": 3348,
+          "name": "paloma"
+        },
+        {
+          "bits": 6111933.479046118,
+          "bpb": 0.8604797535225385,
+          "bytes": 7102937,
+          "documents": 1792,
+          "name": "uncheatable_eval"
+        }
+      ],
+      "datasets": [
+        {
+          "bits": 1228838.7576528506,
+          "bpb": 1.1511974001941558,
+          "bytes": 1067444,
+          "documents": 256,
+          "name": "paloma/4chan"
+        },
+        {
+          "bits": 744395.2816753235,
+          "bpb": 0.9999909748701958,
+          "bytes": 744402,
+          "documents": 256,
+          "name": "paloma/c4_100_domains"
+        },
+        {
+          "bits": 510746.623450029,
+          "bpb": 0.9758749944113071,
+          "bytes": 523373,
+          "documents": 256,
+          "name": "paloma/c4_en"
+        },
+        {
+          "bits": 883951.3671903196,
+          "bpb": 1.0292566788231823,
+          "bytes": 858825,
+          "documents": 256,
+          "name": "paloma/dolma-v1_5"
+        },
+        {
+          "bits": 593512.6817189672,
+          "bpb": 0.660599905079295,
+          "bytes": 898445,
+          "documents": 256,
+          "name": "paloma/dolma_100_programing_languages"
+        },
+        {
+          "bits": 230049.96445715154,
+          "bpb": 1.1276682652736527,
+          "bytes": 204005,
+          "documents": 256,
+          "name": "paloma/dolma_100_subreddits"
+        },
+        {
+          "bits": 722508.2631084317,
+          "bpb": 1.030971989429885,
+          "bytes": 700803,
+          "documents": 256,
+          "name": "paloma/falcon-refinedweb"
+        },
+        {
+          "bits": 62346.38906785704,
+          "bpb": 1.6581927462926418,
+          "bytes": 37599,
+          "documents": 256,
+          "name": "paloma/gab"
+        },
+        {
+          "bits": 5182098.388665768,
+          "bpb": 0.9469771205143053,
+          "bytes": 5472253,
+          "documents": 167,
+          "name": "paloma/m2d2_s2orc_unsplit"
+        },
+        {
+          "bits": 1536336.7291835719,
+          "bpb": 0.9568423705952371,
+          "bytes": 1605632,
+          "documents": 49,
+          "name": "paloma/m2d2_wikipedia_unsplit"
+        },
+        {
+          "bits": 1177911.2243746545,
+          "bpb": 1.1773508053912882,
+          "bytes": 1000476,
+          "documents": 256,
+          "name": "paloma/manosphere_meta_sep"
+        },
+        {
+          "bits": 944236.3845924202,
+          "bpb": 0.9686273909232588,
+          "bytes": 974819,
+          "documents": 256,
+          "name": "paloma/mc4"
+        },
+        {
+          "bits": 37183.46772478334,
+          "bpb": 1.1347493812494915,
+          "bytes": 32768,
+          "documents": 1,
+          "name": "paloma/ptb"
+        },
+        {
+          "bits": 852037.7605005148,
+          "bpb": 0.9596781396816249,
+          "bytes": 887837,
+          "documents": 256,
+          "name": "paloma/redpajama"
+        },
+        {
+          "bits": 25760.05175247373,
+          "bpb": 2.6697120688645177,
+          "bytes": 9649,
+          "documents": 256,
+          "name": "paloma/twitterAAE_HELM_fixed"
+        },
+        {
+          "bits": 952776.4606827862,
+          "bpb": 0.9646483883988104,
+          "bytes": 987693,
+          "documents": 59,
+          "name": "paloma/wikitext_103"
+        },
+        {
+          "bits": 1363757.137822681,
+          "bpb": 1.115051574450863,
+          "bytes": 1223044,
+          "documents": 256,
+          "name": "uncheatable_eval/ao3_english"
+        },
+        {
+          "bits": 1040511.023759437,
+          "bpb": 0.8405873981566546,
+          "bytes": 1237838,
+          "documents": 256,
+          "name": "uncheatable_eval/arxiv_computer_science"
+        },
+        {
+          "bits": 1158270.176130005,
+          "bpb": 0.9034128843815482,
+          "bytes": 1282105,
+          "documents": 256,
+          "name": "uncheatable_eval/arxiv_physics"
+        },
+        {
+          "bits": 776528.0037763122,
+          "bpb": 0.9230655891137014,
+          "bytes": 841249,
+          "documents": 256,
+          "name": "uncheatable_eval/bbc_news"
+        },
+        {
+          "bits": 568104.8678753468,
+          "bpb": 0.6480148147571212,
+          "bytes": 876685,
+          "documents": 256,
+          "name": "uncheatable_eval/github_cpp"
+        },
+        {
+          "bits": 596291.7058161056,
+          "bpb": 0.5924938204271675,
+          "bytes": 1006410,
+          "documents": 256,
+          "name": "uncheatable_eval/github_python"
+        },
+        {
+          "bits": 608470.5638662311,
+          "bpb": 0.957307772214597,
+          "bytes": 635606,
+          "documents": 256,
+          "name": "uncheatable_eval/wikipedia_english"
+        }
+      ],
+      "documents": 5140,
+      "label": "Qwen3 tokenizer, 152k vocab",
+      "model": "qwen3-152k",
+      "overall_bpb": 0.9432109136388666,
+      "paloma_bpb": 0.9799242320092819,
+      "pattern_buckets": [
+        {
+          "bits": 159684.08424275814,
+          "bpb": 1.4405420319599291,
+          "bytes": 110850,
+          "documents": 33576,
+          "name": "text/non_ascii"
+        },
+        {
+          "bits": 322541.4043327502,
+          "bpb": 1.3253510366520391,
+          "bytes": 243363,
+          "documents": 36486,
+          "name": "text/non_ascii_word"
+        },
+        {
+          "bits": 789841.9464586304,
+          "bpb": 1.3578960201535424,
+          "bytes": 581666,
+          "documents": 173710,
+          "name": "text/number"
+        },
+        {
+          "bits": 1345941.6599091804,
+          "bpb": 1.3554242076660117,
+          "bytes": 993004,
+          "documents": 799744,
+          "name": "text/punctuation"
+        },
+        {
+          "bits": 100561.99838435826,
+          "bpb": 1.0314897466905824,
+          "bytes": 97492,
+          "documents": 1923,
+          "name": "text/url"
+        },
+        {
+          "bits": 15106093.23943156,
+          "bpb": 0.8867300221024611,
+          "bytes": 17035730,
+          "documents": 3430328,
+          "name": "text/word"
+        },
+        {
+          "bits": 133496.48173159093,
+          "bpb": 0.35401004972604183,
+          "bytes": 377098,
+          "documents": 47781,
+          "name": "whitespace/mixed"
+        },
+        {
+          "bits": 54650.08557754045,
+          "bpb": 1.5325748219955817,
+          "bytes": 35659,
+          "documents": 13755,
+          "name": "whitespace/multi_newline"
+        },
+        {
+          "bits": 25015.075503241424,
+          "bpb": 0.815168491649279,
+          "bytes": 30687,
+          "documents": 5586,
+          "name": "whitespace/multi_space"
+        },
+        {
+          "bits": 127590.0798613276,
+          "bpb": 1.5670414249558173,
+          "bytes": 81421,
+          "documents": 81421,
+          "name": "whitespace/newline"
+        },
+        {
+          "bits": 3563824.109394971,
+          "bpb": 1.0406574655805327,
+          "bytes": 3424589,
+          "documents": 3424589,
+          "name": "whitespace/single_space"
+        },
+        {
+          "bits": 67383.11001661506,
+          "bpb": 0.691811275208828,
+          "bytes": 97401,
+          "documents": 20609,
+          "name": "whitespace/tab_or_cr"
+        }
+      ],
+      "uncheatable_bpb": 0.8604797535225385
+    },
+    {
+      "bytes": 23108960,
+      "dataset_groups": [
+        {
+          "bits": 15827750.627427034,
+          "bpb": 0.9888621694112919,
+          "bytes": 16006023,
+          "documents": 3348,
+          "name": "paloma"
+        },
+        {
+          "bits": 6147692.9876667475,
+          "bpb": 0.8655142214645501,
+          "bytes": 7102937,
+          "documents": 1792,
+          "name": "uncheatable_eval"
+        }
+      ],
+      "datasets": [
+        {
+          "bits": 1234080.5991378066,
+          "bpb": 1.156108047951749,
+          "bytes": 1067444,
+          "documents": 256,
+          "name": "paloma/4chan"
+        },
+        {
+          "bits": 753052.5318318347,
+          "bpb": 1.0116207799439478,
+          "bytes": 744402,
+          "documents": 256,
+          "name": "paloma/c4_100_domains"
+        },
+        {
+          "bits": 521118.70770708605,
+          "bpb": 0.9956927615812929,
+          "bytes": 523373,
+          "documents": 256,
+          "name": "paloma/c4_en"
+        },
+        {
+          "bits": 896979.6419055437,
+          "bpb": 1.0444265617623425,
+          "bytes": 858825,
+          "documents": 256,
+          "name": "paloma/dolma-v1_5"
+        },
+        {
+          "bits": 582577.7763682487,
+          "bpb": 0.6484289815940305,
+          "bytes": 898445,
+          "documents": 256,
+          "name": "paloma/dolma_100_programing_languages"
+        },
+        {
+          "bits": 237868.89522937505,
+          "bpb": 1.1659954179033605,
+          "bytes": 204005,
+          "documents": 256,
+          "name": "paloma/dolma_100_subreddits"
+        },
+        {
+          "bits": 731641.936131931,
+          "bpb": 1.044005142860306,
+          "bytes": 700803,
+          "documents": 256,
+          "name": "paloma/falcon-refinedweb"
+        },
+        {
+          "bits": 61941.42361700533,
+          "bpb": 1.647422102103921,
+          "bytes": 37599,
+          "documents": 256,
+          "name": "paloma/gab"
+        },
+        {
+          "bits": 5233014.602218919,
+          "bpb": 0.9562815539082201,
+          "bytes": 5472253,
+          "documents": 167,
+          "name": "paloma/m2d2_s2orc_unsplit"
+        },
+        {
+          "bits": 1544453.6315620726,
+          "bpb": 0.9618976400333779,
+          "bytes": 1605632,
+          "documents": 49,
+          "name": "paloma/m2d2_wikipedia_unsplit"
+        },
+        {
+          "bits": 1184706.4241142045,
+          "bpb": 1.184142772154659,
+          "bytes": 1000476,
+          "documents": 256,
+          "name": "paloma/manosphere_meta_sep"
+        },
+        {
+          "bits": 937814.2729065731,
+          "bpb": 0.962039386703145,
+          "bytes": 974819,
+          "documents": 256,
+          "name": "paloma/mc4"
+        },
+        {
+          "bits": 38803.4280707993,
+          "bpb": 1.1841866476684357,
+          "bytes": 32768,
+          "documents": 1,
+          "name": "paloma/ptb"
+        },
+        {
+          "bits": 865903.4487600727,
+          "bpb": 0.9752955201912882,
+          "bytes": 887837,
+          "documents": 256,
+          "name": "paloma/redpajama"
+        },
+        {
+          "bits": 26226.96660249826,
+          "bpb": 2.7181020419212625,
+          "bytes": 9649,
+          "documents": 256,
+          "name": "paloma/twitterAAE_HELM_fixed"
+        },
+        {
+          "bits": 977566.3412630595,
+          "bpb": 0.9897471595557117,
+          "bytes": 987693,
+          "documents": 59,
+          "name": "paloma/wikitext_103"
+        },
+        {
+          "bits": 1391606.6584845926,
+          "bpb": 1.137822235736893,
+          "bytes": 1223044,
+          "documents": 256,
+          "name": "uncheatable_eval/ao3_english"
+        },
+        {
+          "bits": 1042070.6540539579,
+          "bpb": 0.8418473613299623,
+          "bytes": 1237838,
+          "documents": 256,
+          "name": "uncheatable_eval/arxiv_computer_science"
+        },
+        {
+          "bits": 1166051.6914755183,
+          "bpb": 0.9094822120462195,
+          "bytes": 1282105,
+          "documents": 256,
+          "name": "uncheatable_eval/arxiv_physics"
+        },
+        {
+          "bits": 797868.6837033388,
+          "bpb": 0.9484334408758154,
+          "bytes": 841249,
+          "documents": 256,
+          "name": "uncheatable_eval/bbc_news"
+        },
+        {
+          "bits": 549211.8055630933,
+          "bpb": 0.6264642437855025,
+          "bytes": 876685,
+          "documents": 256,
+          "name": "uncheatable_eval/github_cpp"
+        },
+        {
+          "bits": 583596.8912364177,
+          "bpb": 0.5798798613253224,
+          "bytes": 1006410,
+          "documents": 256,
+          "name": "uncheatable_eval/github_python"
+        },
+        {
+          "bits": 617286.6031498295,
+          "bpb": 0.9711780618021691,
+          "bytes": 635606,
+          "documents": 256,
+          "name": "uncheatable_eval/wikipedia_english"
+        }
+      ],
+      "documents": 5140,
+      "label": "TokenMonster English/code, 32k vocab",
+      "model": "tokenmonster-englishcode-32k",
+      "overall_bpb": 0.9509490524495167,
+      "paloma_bpb": 0.9888621694112919,
+      "pattern_buckets": [
+        {
+          "bits": 148644.0160174475,
+          "bpb": 1.3409473704776498,
+          "bytes": 110850,
+          "documents": 33576,
+          "name": "text/non_ascii"
+        },
+        {
+          "bits": 285625.35714671476,
+          "bpb": 1.1736597475652204,
+          "bytes": 243363,
+          "documents": 36486,
+          "name": "text/non_ascii_word"
+        },
+        {
+          "bits": 642722.5227775512,
+          "bpb": 1.10496835430909,
+          "bytes": 581666,
+          "documents": 173710,
+          "name": "text/number"
+        },
+        {
+          "bits": 977967.9502127587,
+          "bpb": 0.984858016898984,
+          "bytes": 993004,
+          "documents": 799744,
+          "name": "text/punctuation"
+        },
+        {
+          "bits": 97089.29323564422,
+          "bpb": 0.9958693352854,
+          "bytes": 97492,
+          "documents": 1923,
+          "name": "text/url"
+        },
+        {
+          "bits": 15944121.938233577,
+          "bpb": 0.9359224370328466,
+          "bytes": 17035730,
+          "documents": 3430328,
+          "name": "text/word"
+        },
+        {
+          "bits": 184163.80920278202,
+          "bpb": 0.488371217038494,
+          "bytes": 377098,
+          "documents": 47781,
+          "name": "whitespace/mixed"
+        },
+        {
+          "bits": 43729.958508699056,
+          "bpb": 1.2263372082419322,
+          "bytes": 35659,
+          "documents": 13755,
+          "name": "whitespace/multi_newline"
+        },
+        {
+          "bits": 27825.515644638348,
+          "bpb": 0.9067525546530566,
+          "bytes": 30687,
+          "documents": 5586,
+          "name": "whitespace/multi_space"
+        },
+        {
+          "bits": 101613.2005411434,
+          "bpb": 1.2479974520227386,
+          "bytes": 81421,
+          "documents": 81421,
+          "name": "whitespace/newline"
+        },
+        {
+          "bits": 3458421.681594467,
+          "bpb": 1.009879340730951,
+          "bytes": 3424589,
+          "documents": 3424589,
+          "name": "whitespace/single_space"
+        },
+        {
+          "bits": 63518.37197829149,
+          "bpb": 0.6521326472858748,
+          "bytes": 97401,
+          "documents": 20609,
+          "name": "whitespace/tab_or_cr"
+        }
+      ],
+      "uncheatable_bpb": 0.8655142214645501
+    }
+  ],
+  "source_experiment": "gs://marin-eu-west4/experiments/exp_tokenizer_sensitivity_d1024_perplexity_gap-c91f6c.json",
+  "source_experiment_browser": "https://marin.community/data-browser/experiment?path=gs%3A//marin-eu-west4/experiments/exp_tokenizer_sensitivity_d1024_perplexity_gap-c91f6c.json",
+  "source_issue_comment": "https://github.com/marin-community/marin/issues/5821#issuecomment-4568564741",
+  "title": "Tokenizer Sensitivity d1024 Gap Dashboard"
+}

--- a/analysis/tokenizer-sensitivity-gap/index.html
+++ b/analysis/tokenizer-sensitivity-gap/index.html
@@ -1,0 +1,212 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tokenizer Sensitivity d1024 Gap Dashboard | Marin</title>
+  <meta name="description" content="Gap-centered dashboard for the patched d1024 tokenizer sensitivity perplexity analysis.">
+  <link rel="canonical" href="https://marin.community/analysis/tokenizer-sensitivity-gap/">
+  <link rel="stylesheet" href="./dashboard.css?v=20260528-heatmaps">
+</head>
+<body>
+  <main class="shell">
+    <header class="topbar">
+      <div>
+        <p class="eyebrow">Tokenizer sensitivity</p>
+        <h1>d1024 perplexity gaps vs llama3-128k</h1>
+        <p class="lede">Patched byte-weighted BPB comparison across Paloma and Uncheatable. Negative gap means the candidate is better than the llama3 tokenizer path on the same scored bytes.</p>
+      </div>
+      <nav class="source-links" aria-label="Sources">
+        <a href="https://marin.community/data-browser/experiment?path=gs%3A//marin-eu-west4/experiments/exp_tokenizer_sensitivity_d1024_perplexity_gap-c91f6c.json">Experiment</a>
+        <a href="https://github.com/marin-community/marin/issues/5821#issuecomment-4568564741">Issue comment</a>
+      </nav>
+    </header>
+
+    <section class="summary-grid" id="summary-grid" aria-label="Headline gaps"></section>
+
+    <div class="layout">
+      <aside class="panel sidebar">
+        <h2>Comparisons</h2>
+        <div id="candidate-list" class="candidate-list"></div>
+        <div class="notes" id="notes"></div>
+      </aside>
+
+      <section class="content">
+        <section class="panel">
+          <div class="panel-head">
+            <div>
+              <h2>Gap Matrix</h2>
+              <p>Candidate BPB minus <code>llama3-128k</code> BPB.</p>
+            </div>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Candidate</th>
+                  <th>Overall</th>
+                  <th>Paloma</th>
+                  <th>Uncheatable</th>
+                  <th>Slice wins</th>
+                </tr>
+              </thead>
+              <tbody id="gap-matrix"></tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="panel selected-panel">
+          <div class="panel-head">
+            <div>
+              <h2 id="selected-title"></h2>
+              <p id="selected-subtitle"></p>
+            </div>
+            <div class="selected-score" id="selected-score"></div>
+          </div>
+          <div class="group-grid" id="group-grid"></div>
+        </section>
+
+        <section class="split">
+          <section class="panel">
+            <div class="panel-head">
+              <div>
+                <h2>Biggest Dataset Moves</h2>
+                <p>Largest candidate wins and losses by dataset-level BPB gap.</p>
+              </div>
+            </div>
+            <div class="move-columns">
+              <div>
+                <h3>Candidate better</h3>
+                <div id="biggest-wins" class="move-list"></div>
+              </div>
+              <div>
+                <h3>Candidate worse</h3>
+                <div id="biggest-losses" class="move-list"></div>
+              </div>
+            </div>
+          </section>
+
+          <section class="panel">
+            <div class="panel-head">
+              <div>
+                <h2>Absolute BPB</h2>
+                <p>Byte-weighted score summaries from the same run.</p>
+              </div>
+            </div>
+            <div class="table-wrap">
+              <table class="score-table">
+                <thead>
+                  <tr>
+                    <th>Tokenizer path</th>
+                    <th>Overall</th>
+                    <th>Paloma</th>
+                    <th>Uncheatable</th>
+                  </tr>
+                </thead>
+                <tbody id="score-table"></tbody>
+              </table>
+            </div>
+          </section>
+        </section>
+
+        <section class="panel">
+          <div class="panel-head controls-head">
+            <div>
+              <h2>Dataset Slices</h2>
+              <p id="dataset-count"></p>
+            </div>
+            <div class="controls">
+              <input id="dataset-search" class="search" placeholder="Filter datasets">
+              <select id="dataset-sort">
+                <option value="abs">Sort by |gap|</option>
+                <option value="gap">Sort by gap</option>
+                <option value="name">Sort by name</option>
+              </select>
+            </div>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Dataset</th>
+                  <th>Gap</th>
+                  <th>Candidate BPB</th>
+                  <th>Baseline BPB</th>
+                  <th>Bytes</th>
+                  <th>Bar</th>
+                </tr>
+              </thead>
+              <tbody id="dataset-table"></tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="panel">
+          <div class="panel-head">
+            <div>
+              <h2>Pattern Buckets</h2>
+              <p>Segment-labeled gap buckets from the report summary.</p>
+            </div>
+          </div>
+          <div class="table-wrap">
+            <table>
+              <thead>
+                <tr>
+                  <th>Bucket</th>
+                  <th>Gap</th>
+                  <th>Candidate BPB</th>
+                  <th>Baseline BPB</th>
+                  <th>Bytes</th>
+                  <th>Bar</th>
+                </tr>
+              </thead>
+              <tbody id="bucket-table"></tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="panel">
+          <div class="panel-head">
+            <div>
+              <h2>Segment Heatmaps</h2>
+              <p>Worst local spans and repeated literals from the report. Color intensity follows local gap size.</p>
+            </div>
+          </div>
+          <div class="heatmap-toolbar" id="heatmap-tabs"></div>
+          <div class="example-columns">
+            <div>
+              <h3>Candidate worse</h3>
+              <div id="heatmaps-worse" class="heatmap-list"></div>
+            </div>
+            <div>
+              <h3>Candidate better</h3>
+              <div id="heatmaps-better" class="heatmap-list"></div>
+            </div>
+          </div>
+        </section>
+
+        <section class="panel">
+          <div class="panel-head">
+            <div>
+              <h2>Example Documents</h2>
+              <p>Report-selected rows with the largest candidate-vs-baseline deltas.</p>
+            </div>
+          </div>
+          <div class="example-columns">
+            <div>
+              <h3>Candidate worse</h3>
+              <div id="examples-worse" class="example-list"></div>
+            </div>
+            <div>
+              <h3>Candidate better</h3>
+              <div id="examples-better" class="example-list"></div>
+            </div>
+          </div>
+        </section>
+      </section>
+    </div>
+  </main>
+
+  <script type="module" src="./dashboard.js?v=20260528-heatmaps"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds a new static dashboard at `analysis/tokenizer-sensitivity-gap/` for the patched d1024 tokenizer sensitivity gap run.
- Centers the view on candidate-vs-`llama3-128k` BPB gaps, with summary cards, gap matrix, dataset moves, pattern buckets, examples, and segment/literal heatmaps.
- Bakes the small extracted report summaries into `data.json` with links back to the GCS experiment and issue comment.
- Disables TokenMonster local heatmaps after an offset audit showed its saved `token_byte_starts` / `token_byte_ends` are shifted relative to prefix-decoded source text; TokenMonster document/dataset gaps remain visible.

## Validation

- `node --check analysis/tokenizer-sensitivity-gap/dashboard.js`
- `python3 -m json.tool analysis/tokenizer-sensitivity-gap/data.json >/dev/null`
- Local static render checked at `http://127.0.0.1:8765/analysis/tokenizer-sensitivity-gap/`.
