### PR TITLE
[codex] Mark TokenMonster heatmaps invalid

### DIFF
--- a/analysis/tokenizer-sensitivity-gap/dashboard.css
+++ b/analysis/tokenizer-sensitivity-gap/dashboard.css
@@ -512,6 +512,21 @@ select {
   margin: -2px 0 12px;
 }
 
+.warning {
+  margin: -2px 0 12px;
+  border: 1px solid #e7b978;
+  border-radius: 8px;
+  background: #fff7e8;
+  color: #65440e;
+  font-size: 13px;
+  line-height: 1.45;
+  padding: 11px 12px;
+}
+
+.warning[hidden] {
+  display: none;
+}
+
 .heatmap-tab {
   min-height: 34px;
   border: 1px solid var(--border-strong);

--- a/analysis/tokenizer-sensitivity-gap/dashboard.js
+++ b/analysis/tokenizer-sensitivity-gap/dashboard.js
@@ -1,4 +1,4 @@
-const ASSET_VERSION = "20260528-heatmaps";
+const ASSET_VERSION = "20260528-offset-audit";
 
 const response = await fetch(`./data.json?v=${ASSET_VERSION}`);
 if (!response.ok) {
@@ -23,6 +23,7 @@ const elements = {
   datasetCount: document.getElementById("dataset-count"),
   datasetTable: document.getElementById("dataset-table"),
   bucketTable: document.getElementById("bucket-table"),
+  heatmapWarning: document.getElementById("heatmap-warning"),
   heatmapTabs: document.getElementById("heatmap-tabs"),
   heatmapsWorse: document.getElementById("heatmaps-worse"),
   heatmapsBetter: document.getElementById("heatmaps-better"),
@@ -242,14 +243,34 @@ function renderBucketTable(gap) {
 }
 
 function renderExamples(gap) {
-  elements.examplesWorse.innerHTML = exampleCards(gap.examples.model_a_worse || []);
-  elements.examplesBetter.innerHTML = exampleCards(gap.examples.model_b_worse || []);
+  const localAttributionInvalid = hasInvalidLocalAttribution(gap);
+  elements.examplesWorse.innerHTML = exampleCards(gap.examples.model_a_worse || [], localAttributionInvalid);
+  elements.examplesBetter.innerHTML = exampleCards(gap.examples.model_b_worse || [], localAttributionInvalid);
 }
 
 function renderHeatmaps(gap) {
+  if (hasInvalidLocalAttribution(gap)) {
+    elements.heatmapWarning.hidden = false;
+    elements.heatmapWarning.innerHTML = `
+      TokenMonster local heatmaps are disabled. An offset audit of the saved
+      <code>scored_documents.parquet</code> found that TokenMonster token byte spans are shifted relative to the decoded source text
+      around capcode / marker behavior. The aggregate and dataset-level BPB rows above are still useful, but local span and literal
+      attribution for TokenMonster needs a scorer fix or token-level losses saved in a new artifact.
+    `;
+    elements.heatmapTabs.hidden = true;
+    elements.heatmapsWorse.innerHTML = `<div class="dataset-meta">Disabled for TokenMonster until byte-offset attribution is regenerated.</div>`;
+    elements.heatmapsBetter.innerHTML = `<div class="dataset-meta">Disabled for TokenMonster until byte-offset attribution is regenerated.</div>`;
+    return;
+  }
+  elements.heatmapWarning.hidden = true;
+  elements.heatmapTabs.hidden = false;
   const key = selectedHeatmapView === "literals" ? "top_literals" : "top_segments";
   elements.heatmapsWorse.innerHTML = heatmapCards(gap[key]?.model_a_worse || [], selectedHeatmapView, "bad");
   elements.heatmapsBetter.innerHTML = heatmapCards(gap[key]?.model_b_worse || [], selectedHeatmapView, "good");
+}
+
+function hasInvalidLocalAttribution(gap) {
+  return gap.model === "tokenmonster-englishcode-32k";
 }
 
 function moveRow(row) {
@@ -265,7 +286,7 @@ function moveRow(row) {
   `;
 }
 
-function exampleCards(rows) {
+function exampleCards(rows, localAttributionInvalid = false) {
   if (!rows.length) {
     return `<div class="dataset-meta">No examples in this bucket.</div>`;
   }
@@ -276,7 +297,7 @@ function exampleCards(rows) {
         <span class="${toneForGap(row.gap_bpb)}">${formatGap(row.gap_bpb)}</span>
       </div>
       <div class="example-meta">
-        ${escapeHtml(row.shard || "unknown shard")} · row ${formatInteger(row.row_index)} · worst bucket ${escapeHtml(row.worst_bucket || "n/a")}
+        ${escapeHtml(row.shard || "unknown shard")} · row ${formatInteger(row.row_index)}${localAttributionInvalid ? " · document gap only" : ` · worst bucket ${escapeHtml(row.worst_bucket || "n/a")}`}
       </div>
       <pre class="example-preview">${escapeHtml(row.preview || "")}</pre>
     </article>

--- a/analysis/tokenizer-sensitivity-gap/index.html
+++ b/analysis/tokenizer-sensitivity-gap/index.html
@@ -6,7 +6,7 @@
   <title>Tokenizer Sensitivity d1024 Gap Dashboard | Marin</title>
   <meta name="description" content="Gap-centered dashboard for the patched d1024 tokenizer sensitivity perplexity analysis.">
   <link rel="canonical" href="https://marin.community/analysis/tokenizer-sensitivity-gap/">
-  <link rel="stylesheet" href="./dashboard.css?v=20260528-heatmaps">
+  <link rel="stylesheet" href="./dashboard.css?v=20260528-offset-audit">
 </head>
 <body>
   <main class="shell">
@@ -172,6 +172,7 @@
               <p>Worst local spans and repeated literals from the report. Color intensity follows local gap size.</p>
             </div>
           </div>
+          <div id="heatmap-warning" class="warning" hidden></div>
           <div class="heatmap-toolbar" id="heatmap-tabs"></div>
           <div class="example-columns">
             <div>
@@ -207,6 +208,6 @@
     </div>
   </main>
 
-  <script type="module" src="./dashboard.js?v=20260528-heatmaps"></script>
+  <script type="module" src="./dashboard.js?v=20260528-offset-audit"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Disables TokenMonster local segment/literal heatmaps in the tokenizer sensitivity dashboard.
- Adds an inline warning explaining that the saved TokenMonster token byte offsets are shifted relative to prefix-decoded source text.
- Leaves aggregate, dataset, and document-level TokenMonster gaps visible while marking examples as document-gap-only.

## Validation

- `node --check analysis/tokenizer-sensitivity-gap/dashboard.js`
- `python3 -m json.tool analysis/tokenizer-sensitivity-gap/data.json >/dev/null`
- Local static render checked at `http://127.0.0.1:8765/analysis/tokenizer-sensitivity-gap/?reload=offset-audit#tokenmonster-englishcode-32k`.
