### PR TITLE
Fix PPL circuit 8B report Jekyll rendering

### DIFF
--- a/analysis/perplexity-gap/artifacts/main_gap_8b_ppl_circuit_coverage_v2_issue6070_v1/marin_8b-vs-qwen3_8b-76a71a/report.md
+++ b/analysis/perplexity-gap/artifacts/main_gap_8b_ppl_circuit_coverage_v2_issue6070_v1/marin_8b-vs-qwen3_8b-76a71a/report.md
@@ -1,3 +1,4 @@
+{% raw %}
 # Perplexity Gap Report
 
 **Model A:** marin-community/marin-8b-base
@@ -348,3 +349,4 @@ Representative token boundaries come from the highest-gap occurrence for each li
 | 643020 | text/number | 1 | 6 | 1.306527 | 3.103649 | -1.797122 | -10.782734 | ppl_circuit_coverage_v2/arithmetic/borrow_subtraction | >>>␠502␠-␠148␠->␠354⏎>>>␠1004␠-␠879␠->␠125⏎>>>␠708200␠-␠65180␠->␠643020⏎ | \|643\|020\| | \|6\|4\|3\|0\|2\|0\| |
 | 3,2,0,0 | text/number | 5 | 35 | 0.843604 | 1.145846 | -0.302242 | -10.578476 | ppl_circuit_coverage_v2/state_machines/brainfuck_lite | …[3,1,0,0],"pointer":0}⏎brainfuck_lite␠cells=4␠program=">++<-+-+<<+<+-++-+--<++"⏎final={"cells":[3,2,0,0],"pointer":0}⏎ | \|3\|,\|2\|,\|0\|,\|0\| | \|3\|,\|2\|,\|0\|,\|0\| |
 | lmf | text/word | 1 | 3 | 1.770703 | 5.293507 | -3.522804 | -10.568411 | ppl_circuit_coverage_v2/string_byte_transforms/string_rotation | …ft("abcdef",␠2)␠->␠'cdefab'⏎rotate_right("abcdef",␠2)␠->␠'efabcd'⏎rotate_left("λateznp/lmffj",␠11)␠->␠'fjλateznp/lmf'⏎ | \|…l\|mf\| | \|…l\|mf\| |
+{% endraw %}


### PR DESCRIPTION
## Summary

- Wrap the generated 8B PPL circuit v2 `report.md` in a Jekyll raw block
- Prevent bracket-matching examples containing `{{...` from being parsed as Liquid

## Validation

- `python3 -m json.tool analysis/perplexity-gap/data.json`
- `python3 -m json.tool analysis/perplexity-gap/span-heatmaps/manifest.json`
- checked all Liquid-like generated `report.md` artifacts are raw-wrapped
- `git diff --check`
- `docker run --rm --entrypoint bash -v "$PWD":/github/workspace -w /github/workspace -e GITHUB_PAGES=true ghcr.io/actions/jekyll-build-pages:v1.0.13 -lc '/usr/local/bundle/bin/github-pages build --source /github/workspace --destination /tmp/marin-site'`